### PR TITLE
Add additional_foreground_window support to [System] section

### DIFF
--- a/DirectX11/IniHandler.cpp
+++ b/DirectX11/IniHandler.cpp
@@ -4452,6 +4452,9 @@ void LoadConfigFile()
 	if (GetIniStringAndLog(L"Rendering", L"fix_MatrixOperand1Multiplier", 0, setting, MAX_PATH))
 		G->decompiler_settings.MatrixPos_MUL1 = readStringParameter(setting);
 
+	if (GetIniString(L"System", L"additional_foreground_window", nullptr, setting, MAX_PATH))
+		G->additionalForegroundWindowTitle = setting;
+
 	// [Hunting]
 	ParseHuntingSection();
 

--- a/DirectX11/globals.h
+++ b/DirectX11/globals.h
@@ -409,6 +409,7 @@ struct Globals
 	float gTime;
 	float gSettingsSaveTime;
 	DWORD ticks_at_launch;
+	std::wstring additionalForegroundWindowTitle;
 
 	wchar_t SHADER_PATH[MAX_PATH];
 	wchar_t SHADER_CACHE_PATH[MAX_PATH];

--- a/DirectX11/input.cpp
+++ b/DirectX11/input.cpp
@@ -529,6 +529,16 @@ void ClearKeyBindings()
 	actions.clear();
 }
 
+static bool IsAdditionalForegroundWindow(HWND hwnd)
+{
+	if (G->additionalForegroundWindowTitle.empty())
+		return false;
+
+	wchar_t title[512] = {};
+	GetWindowTextW(hwnd, title, _countof(title));
+	return wcscmp(title, G->additionalForegroundWindowTitle.c_str()) == 0;
+}
+
 static bool CheckForegroundWindow()
 {
 	DWORD pid;
@@ -536,9 +546,17 @@ static bool CheckForegroundWindow()
 	if (!G->check_foreground_window)
 		return true;
 
-	GetWindowThreadProcessId(GetForegroundWindow(), &pid);
+	HWND hwnd = GetForegroundWindow();
+	if (!hwnd)
+		return false;
 
-	return (pid == GetCurrentProcessId());
+	GetWindowThreadProcessId(hwnd, &pid);
+
+	if (pid == GetCurrentProcessId())
+		return true;
+
+	// Allow additional foreground window matched by title
+	return IsAdditionalForegroundWindow(hwnd);
 }
 
 bool DispatchInputEvents(HackerDevice *device)


### PR DESCRIPTION
Adds support for `additional_foreground_window` key in `[System]` section. When set, XXMI will also process input when the specified window title is in the foreground, in addition to the game window itself.

This is useful for external applications that need to interact with XXMI via keypress without requiring `check_foreground_window = 0`, which could ruin the user experience. Yet still be able to interact seamlessly without needing fragile automatic window switching.