### PR TITLE
Feature: Implement custom save path for command list resources [alt dump = 

### DIFF
--- a/DirectX11/CommandList.cpp
+++ b/DirectX11/CommandList.cpp
@@ -6,6 +6,7 @@
 
 #include <DDSTextureLoader.h>
 #include <WICTextureLoader.h>
+#include <chrono>
 #include <algorithm>
 #include <sstream>
 #include "HackerDevice.h"
@@ -868,6 +869,126 @@ bail:
 	return false;
 }
 
+static bool ParseFrameAnalysisSave(const wchar_t *section,
+		const wchar_t *key, wstring *val,
+		CommandList *explicit_command_list,
+		CommandList *pre_command_list,
+		CommandList *post_command_list,
+		const wstring *ini_namespace)
+{
+	FrameAnalysisSaveCommand *operation = new FrameAnalysisSaveCommand();
+	wchar_t *buf;
+	size_t size = val->size() + 1;
+
+	buf = new wchar_t[size];
+	wcscpy_s(buf, size, val->c_str());
+
+	wchar_t *ptr = buf;
+	wchar_t *target_token = nullptr;
+	wchar_t *filepath_start = nullptr;
+
+	operation->analyse_options = (FrameAnalysisOptions)0;
+
+	while (*ptr) {
+		// Skip whitespace:
+		while (*ptr == L' ' || *ptr == L'\t') {
+			ptr++;
+		}
+		if (!*ptr)
+			break;
+
+		// Start of current token:
+		wchar_t *token_start = ptr;
+
+		// Scan until next whitespace or end:
+		while (*ptr && *ptr != L' ' && *ptr != L'\t') {
+			ptr++;
+		}
+
+		// Null-terminate the token temporarily so we can lookup/parse:
+		wchar_t saved_char = *ptr;
+		*ptr = L'\0';
+
+		FrameAnalysisOptions opt = lookup_enum_val<wchar_t *, FrameAnalysisOptions>(
+			FrameAnalysisOptionNames, token_start, FrameAnalysisOptions::INVALID);
+
+		if (opt != FrameAnalysisOptions::INVALID) {
+			operation->analyse_options |= opt;
+			// Restore character and continue:
+			*ptr = saved_char;
+		} else {
+			// This is our target!
+			target_token = token_start;
+			// Null terminate target_token at the end of the token:
+			*ptr = L'\0';
+			// filepath start is the rest of the string:
+			filepath_start = ptr + 1;
+			break;
+		}
+	}
+
+	if (!target_token || !filepath_start)
+		goto bail;
+
+	// Extract filepath
+	{
+		wchar_t *filepath = filepath_start;
+		while (*filepath == L' ' || *filepath == L'\t' || *filepath == L'"') {
+			filepath++;
+		}
+		size_t filepath_len = wcslen(filepath);
+		while (filepath_len > 0 && (filepath[filepath_len - 1] == L' ' || filepath[filepath_len - 1] == L'\t' || filepath[filepath_len - 1] == L'"' || filepath[filepath_len - 1] == L'\r' || filepath[filepath_len - 1] == L'\n')) {
+			filepath[filepath_len - 1] = L'\0';
+			filepath_len--;
+		}
+
+		if (filepath_len == 0)
+			goto bail;
+
+		// Block absolute paths or directory traversal (security sandbox)
+		if (wcsstr(filepath, L"..") || wcsstr(filepath, L":") || filepath[0] == L'\\' || filepath[0] == L'/')
+			goto bail;
+
+		wstring namespace_path;
+		get_namespaced_section_path(section, &namespace_path);
+		wchar_t full_path[MAX_PATH];
+		GetModuleFileName(migoto_handle, full_path, MAX_PATH);
+		wcsrchr(full_path, L'\\')[1] = 0;
+
+		wstring resolved_template;
+		if (filepath[0] == L'.' && (filepath[1] == L'\\' || filepath[1] == L'/')) {
+			resolved_template = wstring(full_path) + (filepath + 2);
+		} else if (filepath[0] != L'\0' && filepath[1] != L':' && filepath[0] != L'\\' && filepath[0] != L'/') {
+			resolved_template = wstring(full_path) + namespace_path + filepath;
+		} else {
+			resolved_template = filepath;
+		}
+		operation->save_filepath_template = resolved_template;
+	}
+
+	if (!operation->target.ParseTarget(target_token, true, ini_namespace, pre_command_list->scope))
+		goto bail;
+
+	operation->target_name = L"[" + wstring(section) + L"]-" + wstring(target_token);
+	std::replace(operation->target_name.begin(), operation->target_name.end(), L'<', L'_');
+	std::replace(operation->target_name.begin(), operation->target_name.end(), L'>', L'_');
+	std::replace(operation->target_name.begin(), operation->target_name.end(), L':', L'_');
+	std::replace(operation->target_name.begin(), operation->target_name.end(), L'"', L'_');
+	std::replace(operation->target_name.begin(), operation->target_name.end(), L'/', L'_');
+	std::replace(operation->target_name.begin(), operation->target_name.end(), L'\\',L'_');
+	std::replace(operation->target_name.begin(), operation->target_name.end(), L'|', L'_');
+	std::replace(operation->target_name.begin(), operation->target_name.end(), L'?', L'_');
+	std::replace(operation->target_name.begin(), operation->target_name.end(), L'*', L'_');
+
+	delete [] buf;
+	return AddCommandToList(operation, explicit_command_list, pre_command_list, NULL, NULL, section, key, val);
+
+bail:
+	delete [] buf;
+	delete operation;
+	return false;
+}
+
 bool ParseStoreCommand(const wchar_t* section,
 	const wchar_t* key, wstring* val,
 	CommandList* explicit_command_list,
@@ -975,6 +1096,9 @@ bool ParseCommandListGeneralCommands(const wchar_t *section,
 
 	if (!wcscmp(key, L"dump"))
 		return ParseFrameAnalysisDump(section, key, val, explicit_command_list, pre_command_list, post_command_list, ini_namespace);
+
+	if (!wcscmp(key, L"save"))
+		return ParseFrameAnalysisSave(section, key, val, explicit_command_list, pre_command_list, post_command_list, ini_namespace);
 
 	if (!wcscmp(key, L"special")) {
 		if (!wcscmp(val->c_str(), L"upscaling_switch_bb"))
@@ -1586,6 +1710,9 @@ void FrameAnalysisDumpCommand::run(CommandListState *state)
 	UINT buf_size = 0;
 	DXGI_FORMAT format = DXGI_FORMAT_UNKNOWN;
 
+	if (!G->export_command_list_dump)
+		return;
+
 	// Fast exit if frame analysis is currently inactive:
 	if (!G->analyse_frame)
 		return;
@@ -1613,7 +1740,127 @@ void FrameAnalysisDumpCommand::run(CommandListState *state)
 
 bool FrameAnalysisDumpCommand::noop(bool post, bool ignore_cto_pre, bool ignore_cto_post)
 {
-	return (G->hunting == HUNTING_MODE_DISABLED || G->frame_analysis_registered == false);
+	return !G->export_command_list_dump || (G->hunting == HUNTING_MODE_DISABLED || G->frame_analysis_registered == false);
+}
+
+static wstring FormatSavePath(const wstring &template_path, CommandListState *state)
+{
+	wstring result = template_path;
+
+	SYSTEMTIME lt;
+	GetLocalTime(&lt);
+
+	wchar_t date_str[32];
+	swprintf_s(date_str, L"%04u-%02u-%02u", lt.wYear, lt.wMonth, lt.wDay);
+
+	wchar_t time_str[32];
+	swprintf_s(time_str, L"%02u-%02u-%02u", lt.wHour, lt.wMinute, lt.wSecond);
+
+	wchar_t ms_str[32];
+	swprintf_s(ms_str, L"%03u", lt.wMilliseconds);
+
+	auto now = std::chrono::high_resolution_clock::now();
+	auto duration = now.time_since_epoch();
+	auto micros = std::chrono::duration_cast<std::chrono::microseconds>(duration).count() % 1000000;
+	wchar_t us_str[32];
+	swprintf_s(us_str, L"%06llu", micros);
+
+	wchar_t frame_str[32];
+	swprintf_s(frame_str, L"%u", G->frame_no);
+
+	wchar_t draw_str[32];
+	swprintf_s(draw_str, L"%u", state->mHackerContext ? state->mHackerContext->GetDrawCall() : 0);
+
+	auto replace_all = [](wstring &str, const wstring &from, const wstring &to) {
+		size_t start_pos = 0;
+		while ((start_pos = str.find(from, start_pos)) != wstring::npos) {
+			str.replace(start_pos, from.length(), to);
+			start_pos += to.length();
+		}
+	};
+
+	replace_all(result, L"%DATE%", date_str);
+	replace_all(result, L"%date%", date_str);
+	replace_all(result, L"%TIME%", time_str);
+	replace_all(result, L"%time%", time_str);
+	replace_all(result, L"%MS%", ms_str);
+	replace_all(result, L"%ms%", ms_str);
+	replace_all(result, L"%US%", us_str);
+	replace_all(result, L"%us%", us_str);
+	replace_all(result, L"%FRAME%", frame_str);
+	replace_all(result, L"%frame%", frame_str);
+	replace_all(result, L"%DRAW%", draw_str);
+	replace_all(result, L"%draw%", draw_str);
+
+	size_t start_pos = 0;
+	while ((start_pos = result.find(L'%', start_pos)) != wstring::npos) {
+		size_t end_pos = result.find(L'%', start_pos + 1);
+		if (end_pos == wstring::npos)
+			break;
+
+		wstring var_name = result.substr(start_pos + 1, end_pos - start_pos - 1);
+		if (var_name != L"DATE" && var_name != L"date" &&
+			var_name != L"TIME" && var_name != L"time" &&
+			var_name != L"MS" && var_name != L"ms" &&
+			var_name != L"US" && var_name != L"us" &&
+			var_name != L"FRAME" && var_name != L"frame" &&
+			var_name != L"DRAW" && var_name != L"draw") {
+			wstring var_name_lower = var_name;
+			std::transform(var_name_lower.begin(), var_name_lower.end(), var_name_lower.begin(), ::tolower);
+			auto it = command_list_globals.find(var_name_lower);
+			if (it != command_list_globals.end()) {
+				wchar_t val_str[64];
+				if (it->second.fval == (int)it->second.fval) {
+					swprintf_s(val_str, L"%i", (int)it->second.fval);
+				} else {
+					swprintf_s(val_str, L"%f", it->second.fval);
+				}
+				result.replace(start_pos, end_pos - start_pos + 1, val_str);
+				start_pos += wcslen(val_str);
+				continue;
+			}
+		}
+		start_pos = end_pos + 1;
+	}
+
+	return result;
+}
+
+void FrameAnalysisSaveCommand::run(CommandListState *state)
+{
+	ID3D11Resource *resource = NULL;
+	ID3D11View *view = NULL;
+	UINT stride = 0;
+	UINT offset = 0;
+	UINT buf_size = 0;
+	DXGI_FORMAT format = DXGI_FORMAT_UNKNOWN;
+
+	if (!G->export_command_list_save)
+		return;
+
+	COMMAND_LIST_LOG(state, "%S\n", ini_line.c_str());
+
+	resource = target.GetResource(state, &view, &stride, &offset, &format, NULL);
+	if (!resource) {
+		COMMAND_LIST_LOG(state, "  No resource to save\n");
+		return;
+	}
+
+	FillInMissingInfo(target.type, resource, view, &stride, &offset, &buf_size, &format);
+
+	wstring resolved_filepath = FormatSavePath(save_filepath_template, state);
+
+	state->mHackerContext->FrameAnalysisSave(resource, analyse_options, resolved_filepath.c_str(), format, stride, offset);
+
+	if (resource)
+		resource->Release();
+	if (view)
+		view->Release();
+}
+
+bool FrameAnalysisSaveCommand::noop(bool post, bool ignore_cto_pre, bool ignore_cto_post)
+{
+	return !G->export_command_list_save;
 }
 
 UpscalingFlipBBCommand::UpscalingFlipBBCommand(wstring section) :
@@ -6469,7 +6716,7 @@ void ResourceCopyTarget::FindTextureOverrides(CommandListState *state, bool *res
 
 	// For vertex and index buffers the game may pack multiple meshes into
 	// one buffer and bind them at different offsets. In that case the base
-	// resource hash alone is not enough – we must use the same region data hash 
+	// resource hash alone is not enough Â– we must use the same region data hash 
 	// that IASetVertexBuffers / IASetIndexBuffer computed and stored in 
 	// mCurrentVertexBuffers[] /mCurrentIndexBuffer, and that the hunting overlay displays.
 	// That way the hash the user copies from the overlay matches the one looked up

--- a/DirectX11/CommandList.h
+++ b/DirectX11/CommandList.h
@@ -1244,6 +1244,17 @@ public:
 	bool noop(bool post, bool ignore_cto_pre, bool ignore_cto_post) override;
 };
 
+class FrameAnalysisSaveCommand : public CommandListCommand {
+public:
+	ResourceCopyTarget target;
+	wstring target_name;
+	FrameAnalysisOptions analyse_options;
+	wstring save_filepath_template;
+
+	void run(CommandListState*) override;
+	bool noop(bool post, bool ignore_cto_pre, bool ignore_cto_post) override;
+};
+
 class UpscalingFlipBBCommand : public CommandListCommand {
 public:
 	wstring ini_section;

--- a/DirectX11/FrameAnalysis.cpp
+++ b/DirectX11/FrameAnalysis.cpp
@@ -8,6 +8,8 @@
 #include "Globals.h"
 #include "input.h"
 
+#include <chrono>
+
 #include <ScreenGrab.h>
 #include <wincodec.h>
 #include <Strsafe.h>
@@ -3009,6 +3011,202 @@ void FrameAnalysisContext::FrameAnalysisDump(ID3D11Resource *resource, FrameAnal
 	LeaveCriticalSection(&G->mCriticalSection);
 
 	non_draw_call_dump_counter++;
+}
+
+static void CreateDirectoryRecursive(const wstring &path)
+{
+	wchar_t folder[MAX_PATH];
+	wcsncpy_s(folder, path.c_str(), MAX_PATH);
+
+	wchar_t *last_slash = wcsrchr(folder, L'\\');
+	if (last_slash) {
+		*last_slash = L'\0';
+	} else {
+		last_slash = wcsrchr(folder, L'/');
+		if (last_slash) {
+			*last_slash = L'\0';
+		} else {
+			return; // no separator, folder is current dir
+		}
+	}
+
+	wchar_t current[MAX_PATH] = { 0 };
+	wchar_t *part = folder;
+	wchar_t *next_slash = NULL;
+
+	if (wcslen(part) >= 2 && part[1] == L':') {
+		wcsncpy_s(current, part, 3);
+		part += 3;
+	}
+
+	while (true) {
+		wchar_t *slash_backslash = wcschr(part, L'\\');
+		wchar_t *slash_forward = wcschr(part, L'/');
+		
+		if (slash_backslash && slash_forward) {
+			next_slash = (slash_backslash < slash_forward) ? slash_backslash : slash_forward;
+		} else {
+			next_slash = slash_backslash ? slash_backslash : slash_forward;
+		}
+
+		if (!next_slash)
+			break;
+
+		*next_slash = L'\0';
+		wcsncat_s(current, part, MAX_PATH);
+		wcsncat_s(current, L"\\", MAX_PATH);
+		CreateDirectoryEnsuringAccess(current);
+		part = next_slash + 1;
+	}
+
+	if (*part != L'\0') {
+		wcsncat_s(current, part, MAX_PATH);
+		CreateDirectoryEnsuringAccess(current);
+	}
+}
+
+void FrameAnalysisContext::FrameAnalysisSave(ID3D11Resource *resource, FrameAnalysisOptions options,
+		const wchar_t *custom_filepath, DXGI_FORMAT format, UINT stride, UINT offset)
+{
+	if (!resource) {
+		FALogErr(L"FrameAnalysisSave: Resource is NULL, skipping save to %ls\n", custom_filepath);
+		return;
+	}
+
+	D3D11_RESOURCE_DIMENSION dim;
+	HRESULT hr;
+
+	CreateDirectoryRecursive(custom_filepath);
+
+	resource->GetType(&dim);
+
+	EnterCriticalSectionPretty(&G->mCriticalSection);
+	setlocale(LC_CTYPE, "en_US.UTF-8");
+	
+	FrameAnalysisOptions old_analyse_options = analyse_options;
+	// If no format is specified in options, infer from extension
+	if (!((int)options & ((int)FrameAnalysisOptions::FMT_2D_MASK | (int)FrameAnalysisOptions::FMT_BUF_MASK))) {
+		wstring path_str = custom_filepath;
+		size_t dot = path_str.find_last_of(L'.');
+		if (dot != wstring::npos) {
+			wstring ext = path_str.substr(dot + 1);
+			for (auto &c : ext) {
+				c = ::towlower(c);
+			}
+			if (ext == L"dds") {
+				options |= FrameAnalysisOptions::FMT_2D_DDS;
+			} else if (ext == L"jpg" || ext == L"jpeg" || ext == L"png") {
+				options |= FrameAnalysisOptions::FMT_2D_AUTO;
+			} else if (ext == L"txt") {
+				options |= FrameAnalysisOptions::FMT_BUF_TXT;
+			} else if (ext == L"bin" || ext == L"buf") {
+				options |= FrameAnalysisOptions::FMT_BUF_BIN;
+			}
+		}
+	}
+	analyse_options = options;
+
+	switch (dim) {
+		case D3D11_RESOURCE_DIMENSION_BUFFER:
+		{
+			ID3D11Buffer *buffer = (ID3D11Buffer*)resource;
+			D3D11_BUFFER_DESC desc, orig_desc;
+			ID3D11Buffer *staging = NULL;
+
+			buffer->GetDesc(&desc);
+			memcpy(&orig_desc, &desc, sizeof(D3D11_BUFFER_DESC));
+
+			desc.Usage = D3D11_USAGE_STAGING;
+			desc.BindFlags = 0;
+			desc.MiscFlags = 0;
+			desc.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
+
+			LockResourceCreationMode();
+			hr = GetHackerDevice()->GetPassThroughOrigDevice1()->CreateBuffer(&desc, NULL, &staging);
+			UnlockResourceCreationMode();
+			if (SUCCEEDED(hr)) {
+				GetDumpingContext()->CopyResource(staging, buffer);
+				
+				D3D11_MAPPED_SUBRESOURCE map;
+				hr = GetDumpingContext()->Map(staging, 0, D3D11_MAP_READ, 0, &map);
+				if (SUCCEEDED(hr)) {
+					if (options & FrameAnalysisOptions::FMT_BUF_BIN) {
+						FILE *fd = NULL;
+						errno_t err = wfopen_ensuring_access(&fd, custom_filepath, L"wb");
+						if (fd) {
+							fwrite(map.pData, 1, orig_desc.ByteWidth, fd);
+							fclose(fd);
+						} else {
+							FALogErr(L"Unable to create %ls: %u\n", custom_filepath, err);
+						}
+					}
+					if (options & FrameAnalysisOptions::FMT_BUF_TXT) {
+						char type_char = 'c';
+						if (options & FrameAnalysisOptions::DUMP_VB) type_char = 'v';
+						else if (options & FrameAnalysisOptions::DUMP_IB) type_char = 'i';
+						
+						DumpBufferTxt(const_cast<wchar_t*>(custom_filepath), &map, orig_desc.ByteWidth, type_char, -1, stride, offset);
+					}
+					GetDumpingContext()->Unmap(staging, 0);
+				} else {
+					FALogErr(L"FrameAnalysisSave failed to map staging resource: 0x%x\n", hr);
+				}
+				staging->Release();
+			} else {
+				FALogErr(L"FrameAnalysisSave failed to create staging buffer: 0x%x\n", hr);
+			}
+			break;
+		}
+		case D3D11_RESOURCE_DIMENSION_TEXTURE2D:
+		{
+			ID3D11Texture2D *tex = (ID3D11Texture2D*)resource;
+			ID3D11Texture2D *staging = tex;
+			D3D11_TEXTURE2D_DESC staging_desc;
+
+			tex->GetDesc(&staging_desc);
+			if ((staging_desc.Usage != D3D11_USAGE_STAGING) || !(staging_desc.CPUAccessFlags & D3D11_CPU_ACCESS_READ) || (staging_desc.Format != format)) {
+				hr = StageResource(tex, &staging_desc, &staging, format);
+				if (FAILED(hr)) {
+					analyse_options = old_analyse_options;
+					setlocale(LC_CTYPE, G->gDefaultLocale.c_str());
+					LeaveCriticalSection(&G->mCriticalSection);
+					return;
+				}
+			}
+
+			CoInitializeEx(NULL, COINIT_APARTMENTTHREADED);
+
+			if (options & FrameAnalysisOptions::FMT_2D_JPS || options & FrameAnalysisOptions::FMT_2D_AUTO) {
+				wstring path_str = custom_filepath;
+				GUID container_format = GUID_ContainerFormatJpeg;
+				if (path_str.size() >= 4 && _wcsicmp(path_str.substr(path_str.size() - 4).c_str(), L".png") == 0) {
+					container_format = GUID_ContainerFormatPng;
+				}
+				hr = DirectX::SaveWICTextureToFile(GetDumpingContext(), staging, container_format, custom_filepath);
+				if (FAILED(hr)) {
+					FALogErr(L"Failed to save WIC texture to %ls: 0x%x\n", custom_filepath, hr);
+				}
+			} else if (options & FrameAnalysisOptions::FMT_2D_DDS) {
+				hr = DirectX::SaveDDSTextureToFile(GetDumpingContext(), staging, custom_filepath);
+				if (FAILED(hr)) {
+					FALogErr(L"Failed to save DDS texture to %ls: 0x%x\n", custom_filepath, hr);
+				}
+			}
+
+			CoUninitialize();
+
+			if (staging != tex)
+				staging->Release();
+			break;
+		}
+		default:
+			FALogInfo(L"Skipped saving resource of unsupported type %i: %ls\n", dim, custom_filepath);
+			break;
+	}
+
+	analyse_options = old_analyse_options;
+	setlocale(LC_CTYPE, G->gDefaultLocale.c_str());
+	LeaveCriticalSection(&G->mCriticalSection);
 }
 
 // -----------------------------------------------------------------------------------------------

--- a/DirectX11/FrameAnalysis.h
+++ b/DirectX11/FrameAnalysis.h
@@ -235,6 +235,9 @@ public:
 	void FrameAnalysisTrigger(FrameAnalysisOptions new_options) override;
 	void FrameAnalysisDump(ID3D11Resource *resource, FrameAnalysisOptions options,
 		const wchar_t *target, DXGI_FORMAT format, UINT stride, UINT offset) override;
+	void FrameAnalysisSave(ID3D11Resource *resource, FrameAnalysisOptions options,
+		const wchar_t *custom_filepath, DXGI_FORMAT format, UINT stride, UINT offset) override;
+	unsigned GetDrawCall() override { return draw_call; };
 
 	/*** IUnknown methods ***/
 

--- a/DirectX11/HackerContext.h
+++ b/DirectX11/HackerContext.h
@@ -236,6 +236,9 @@ public:
 	virtual void FrameAnalysisTrigger(FrameAnalysisOptions new_options) {};
 	virtual void FrameAnalysisDump(ID3D11Resource *resource, FrameAnalysisOptions options,
 		const wchar_t *target, DXGI_FORMAT format, UINT stride, UINT offset) {};
+	virtual void FrameAnalysisSave(ID3D11Resource *resource, FrameAnalysisOptions options,
+		const wchar_t *custom_filepath, DXGI_FORMAT format, UINT stride, UINT offset) {};
+	virtual unsigned GetDrawCall() { return 0; };
 
 	// These are the shaders the game has set, which may be different from
 	// the ones we have bound to the pipeline:

--- a/DirectX11/IniHandler.cpp
+++ b/DirectX11/IniHandler.cpp
@@ -354,7 +354,7 @@ static bool _get_namespaced_section_path(IniSections *custom_ini_sections, const
 	return true;
 }
 
-static bool get_namespaced_section_path(const wchar_t *section, wstring *ret)
+bool get_namespaced_section_path(const wchar_t *section, wstring *ret)
 {
 	return _get_namespaced_section_path(&ini_sections, section, ret);
 }
@@ -4422,6 +4422,8 @@ void LoadConfigFile()
 	G->EXPORT_HLSL = GetIniInt(L"Rendering", L"export_hlsl", 0, NULL);
 	G->EXPORT_BINARY = GetIniBool(L"Rendering", L"export_binary", false, NULL);
 	G->DumpUsage = GetIniBool(L"Rendering", L"dump_usage", false, NULL);
+	G->export_command_list_dump = GetIniBool(L"Rendering", L"export_command_list_dump", true, NULL);
+	G->export_command_list_save = GetIniBool(L"Rendering", L"export_command_list_save", true, NULL);
 
 	G->IniParamsReg = GetIniInt(L"Rendering", L"ini_params", 120, NULL);
 	G->decompiler_settings.IniParamsReg = G->IniParamsReg;

--- a/DirectX11/IniHandler.h
+++ b/DirectX11/IniHandler.h
@@ -51,3 +51,5 @@ T2 GetIniEnumClass(const wchar_t *section, const wchar_t *key, T2 def, bool *fou
 bool get_namespaced_section_name_lower(const wstring *section, const wstring *ini_namespace, wstring *ret);
 bool get_section_namespace(const wchar_t *section, wstring *ret);
 wstring get_namespaced_var_name_lower(const wstring var, const wstring *ini_namespace);
+bool get_namespaced_section_path(const wchar_t *section, wstring *ret);
+

--- a/DirectX11/globals.h
+++ b/DirectX11/globals.h
@@ -468,6 +468,7 @@ struct Globals
 	int texture_hash_version;
 	int EXPORT_HLSL;		// 0=off, 1=HLSL only, 2=HLSL+OriginalASM, 3= HLSL+OriginalASM+recompiledASM
 	bool EXPORT_SHADERS, EXPORT_FIXED, EXPORT_BINARY, CACHE_SHADERS, SCISSOR_DISABLE;
+	bool export_command_list_dump, export_command_list_save;
 	int track_texture_updates;
 	bool assemble_signature_comments;
 	bool disassemble_undecipherable_custom_data;
@@ -679,6 +680,8 @@ struct Globals
 		EXPORT_FIXED(false),
 		EXPORT_BINARY(false),
 		CACHE_SHADERS(false),
+		export_command_list_dump(true),
+		export_command_list_save(true),
 		DumpUsage(false),
 		ENABLE_TUNE(false),
 		gTuneStep(0.001f),


### PR DESCRIPTION
Allows staging and saving resources (textures, buffers) to a customizable path in command lists. Includes case-insensitive placeholder substitution, 3dmigoto-relative pathing, and global gating flags in d3dx.ini.