### PR TITLE
alternative custom dump options

### DIFF
--- a/DirectX11/CommandList.cpp
+++ b/DirectX11/CommandList.cpp
@@ -18,6 +18,7 @@
 #include "cursor.h"
 
 #include <D3DCompiler.h>
+#include <Shlwapi.h>
 
 CustomResources customResources;
 CustomResourcePools customResourcePools;
@@ -1132,6 +1133,122 @@ bail:
 	return false;
 }
 
+static bool GetMigotoPath(wstring *path)
+{
+	wchar_t module[MAX_PATH];
+	wchar_t *slash;
+	DWORD length = GetModuleFileName(migoto_handle, module, MAX_PATH);
+
+	if (!length || length >= MAX_PATH || !(slash = wcsrchr(module, L'\\')))
+		return false;
+	slash[1] = 0;
+	*path = module;
+	return true;
+}
+
+static bool PathWithin(const wstring &path, wstring directory)
+{
+	std::replace(directory.begin(), directory.end(), L'/', L'\\');
+	if (directory.empty() || directory.back() != L'\\')
+		directory += L'\\';
+	return path.size() >= directory.size() && !_wcsnicmp(path.c_str(), directory.c_str(), directory.size());
+}
+
+static bool CanonicalPath(const wstring &path, wstring *canonical)
+{
+	wchar_t buffer[MAX_PATH];
+	DWORD length = GetFullPathName(path.c_str(), MAX_PATH, buffer, NULL);
+
+	if (!length || length >= MAX_PATH)
+		return false;
+	*canonical = buffer;
+	std::replace(canonical->begin(), canonical->end(), L'/', L'\\');
+	return true;
+}
+
+static FrameAnalysisOptions SaveFormat(const wstring &path, D3D11_RESOURCE_DIMENSION dimension)
+{
+	const wchar_t *extension = wcsrchr(path.c_str(), L'.');
+	if (!extension)
+		return FrameAnalysisOptions::INVALID;
+
+	if (dimension == D3D11_RESOURCE_DIMENSION_UNKNOWN || dimension == D3D11_RESOURCE_DIMENSION_TEXTURE2D) {
+		if (!_wcsicmp(extension, L".dds"))
+			return FrameAnalysisOptions::FMT_2D_DDS;
+		if (!_wcsicmp(extension, L".png") || !_wcsicmp(extension, L".jpg") ||
+				!_wcsicmp(extension, L".jpeg") || !_wcsicmp(extension, L".bmp"))
+			return FrameAnalysisOptions::FMT_2D_AUTO;
+	}
+	if (dimension == D3D11_RESOURCE_DIMENSION_UNKNOWN || dimension == D3D11_RESOURCE_DIMENSION_BUFFER) {
+		if (!_wcsicmp(extension, L".txt"))
+			return FrameAnalysisOptions::FMT_BUF_TXT;
+		if (!_wcsicmp(extension, L".buf") || !_wcsicmp(extension, L".bin") ||
+				!_wcsicmp(extension, L".ib") || !_wcsicmp(extension, L".vb"))
+			return FrameAnalysisOptions::FMT_BUF_BIN;
+	}
+	return FrameAnalysisOptions::INVALID;
+}
+
+static bool SavePathIsSafe(const wstring &candidate, const wstring &ini_directory)
+{
+	static const wchar_t *protected_directories[] = {
+		L"Core", L"ShaderFixes", L"ShaderCache", L"ShaderFromGame"
+	};
+	wstring root, path;
+	size_t slash;
+
+	if (!GetMigotoPath(&root) || candidate.find_first_of(L"<>\"|?*") != wstring::npos ||
+			!CanonicalPath(candidate, &path) ||
+			path.find(L" \\") != wstring::npos || path.find(L".\\") != wstring::npos ||
+			candidate.find(L':', 2) != wstring::npos || !PathWithin(path, root))
+		return false;
+
+	slash = path.find(L'\\', root.size());
+	if (slash == wstring::npos || slash == root.size() ||
+			SaveFormat(path, D3D11_RESOURCE_DIMENSION_UNKNOWN) == FrameAnalysisOptions::INVALID)
+		return false;
+
+	for (const wchar_t *directory : protected_directories)
+		if (PathWithin(path, root + directory))
+			return false;
+	if ((G->SHADER_PATH[0] && PathWithin(path, G->SHADER_PATH)) ||
+			(G->SHADER_CACHE_PATH[0] && PathWithin(path, G->SHADER_CACHE_PATH)))
+		return false;
+
+	if (PathWithin(path, root + L"Mods")) {
+		if (ini_directory.size() <= 5 || _wcsnicmp(ini_directory.c_str(), L"Mods\\", 5) ||
+				!PathWithin(path, root + ini_directory))
+			return false;
+	}
+
+	for (slash = root.size(); (slash = path.find(L'\\', slash)) != wstring::npos; slash++) {
+		DWORD attributes = GetFileAttributes(path.substr(0, slash).c_str());
+		if (attributes != INVALID_FILE_ATTRIBUTES && attributes & FILE_ATTRIBUTE_REPARSE_POINT)
+			return false;
+	}
+	DWORD attributes = GetFileAttributes(path.c_str());
+	return attributes == INVALID_FILE_ATTRIBUTES || !(attributes & FILE_ATTRIBUTE_REPARSE_POINT);
+}
+
+static bool ResolveSavePath(const wstring &filename, wstring *ini_directory, wstring *path)
+{
+	wstring root, source_directory, canonical_directory;
+
+	if (filename.empty() || !PathIsRelativeW(filename.c_str()) || !GetMigotoPath(&root))
+		return false;
+	if (!ini_directory->empty()) {
+		source_directory = PathIsRelativeW(ini_directory->c_str()) ? root + *ini_directory : *ini_directory;
+		if (!CanonicalPath(source_directory, &canonical_directory) || !PathWithin(canonical_directory, root))
+			return false;
+		*ini_directory = canonical_directory.substr(root.size());
+		if (!ini_directory->empty() && ini_directory->back() != L'\\')
+			*ini_directory += L'\\';
+	}
+	return CanonicalPath(root + (filename.size() > 1 && filename[0] == L'.' &&
+		(filename[1] == L'\\' || filename[1] == L'/') ? filename.substr(2) : *ini_directory + filename), path) &&
+		SavePathIsSafe(*path, *ini_directory);
+}
+
 static bool ParseFrameAnalysisDump(const wchar_t *section,
 		const wchar_t *key, wstring *val,
 		CommandList *explicit_command_list,
@@ -1139,26 +1256,56 @@ static bool ParseFrameAnalysisDump(const wchar_t *section,
 		CommandList *post_command_list,
 		const wstring *ini_namespace)
 {
-	FrameAnalysisDumpCommand *operation = new FrameAnalysisDumpCommand();
-	wchar_t *buf;
-	size_t size = val->size() + 1;
+	auto operation = make_unique<FrameAnalysisDumpCommand>();
+	bool save = !wcscmp(key, L"save");
+	wstring target_args = *val;
+	wstring filename, source_ini, ini_directory;
+	vector<wchar_t> buf;
 	wchar_t *target = NULL;
 
-	// parse_enum_option_string replaces spaces with NULLs, so it can't
-	// operate on the buffer in the wstring directly. I could potentially
-	// change it to work without modifying the string, but for now it's
-	// easier to just make a copy of the string:
-	buf = new wchar_t[size];
-	wcscpy_s(buf, size, val->c_str());
+	if (save) {
+		CommandArgumentReader args(L"save", *val, section, ini_namespace, pre_command_list->scope);
+		if (!args.GetToken(&target_args, CommandArgumentReader::PeekMode::Argument) ||
+				!args.ConsumeSeparator(SeparatorMode::Comma) ||
+				!args.GetToken(&filename, CommandArgumentReader::PeekMode::Argument))
+			return args.Fail();
+		if (args.HasMore() && (!args.ConsumeSeparator(SeparatorMode::Comma) ||
+				!args.GetUInt(&operation->save_limit)))
+			return args.Fail();
+		if (!args.Finished())
+			return args.Fail();
+		if (!operation->save_limit || (G->export_command_list_save_count &&
+				G->export_command_list_save_count < operation->save_limit))
+			operation->save_limit = G->export_command_list_save_count;
+		if (filename.size() >= 2 && filename.front() == L'"' && filename.back() == L'"')
+			filename = filename.substr(1, filename.size() - 2);
+
+		if (!get_section_path(section, &source_ini))
+			source_ini = L"d3dx.ini";
+		size_t slash = source_ini.find_last_of(L"\\/");
+		if (slash != wstring::npos)
+			ini_directory = source_ini.substr(0, slash + 1);
+		if (!ResolveSavePath(filename, &ini_directory, &operation->save_path) ||
+				!_wcsicmp(ini_directory.c_str(), L"Mods\\")) {
+			LogOverlayW(LOG_WARNING_ALWAYS,
+				L"save= blocked invalid path: %ls\nSource: %ls\n", filename.c_str(), source_ini.c_str());
+			return false;
+		}
+		operation->save_directory = ini_directory;
+		operation->source_ini = source_ini;
+	}
+
+	buf.assign(target_args.begin(), target_args.end());
+	buf.push_back(0);
 
 	operation->analyse_options = parse_enum_option_string<wchar_t *, FrameAnalysisOptions>
-		(FrameAnalysisOptionNames, buf, &target);
+		(FrameAnalysisOptionNames, buf.data(), &target);
 
 	if (!target)
-		goto bail;
+		return false;
 
 	if (!operation->target.ParseTarget(target, true, ini_namespace, pre_command_list->scope))
-		goto bail;
+		return false;
 
 	operation->target_name = L"[" + wstring(section) + L"]-" + wstring(target);
 	// target_name will be used in the filenames, so replace any reserved characters:
@@ -1172,13 +1319,7 @@ static bool ParseFrameAnalysisDump(const wchar_t *section,
 	std::replace(operation->target_name.begin(), operation->target_name.end(), L'?', L'_');
 	std::replace(operation->target_name.begin(), operation->target_name.end(), L'*', L'_');
 
-	delete [] buf;
-	return AddCommandToList(operation, explicit_command_list, pre_command_list, NULL, NULL, section, key, val);
-
-bail:
-	delete [] buf;
-	delete operation;
-	return false;
+	return AddCommandToList(operation.release(), explicit_command_list, pre_command_list, NULL, NULL, section, key, val);
 }
 
 bool ParseStoreCommand(const wchar_t* section,
@@ -1257,7 +1398,7 @@ bool ParseCommandListGeneralCommands(const wchar_t *section,
 	if (!wcscmp(key, L"analyse_options"))
 		return AddCommandToList(new FrameAnalysisChangeOptionsCommand(val), explicit_command_list, pre_command_list, NULL, NULL, section, key, val);
 
-	if (!wcscmp(key, L"dump"))
+	if (!wcscmp(key, L"dump") || !wcscmp(key, L"save"))
 		return ParseFrameAnalysisDump(section, key, val, explicit_command_list, pre_command_list, post_command_list, ini_namespace);
 
 	if (!wcscmp(key, L"special")) {
@@ -1968,6 +2109,55 @@ static void FillInMissingInfo(ResourceCopyTargetType type, ID3D11Resource *resou
 	}
 }
 
+static void ReplacePathToken(wstring *path, const wchar_t *token, const wchar_t *value)
+{
+	size_t pos = 0, length = wcslen(token), value_length = wcslen(value);
+	while (pos + length <= path->size()) {
+		if (_wcsnicmp(path->c_str() + pos, token, length)) {
+			pos++;
+			continue;
+		}
+		path->replace(pos, length, value);
+		pos += value_length;
+	}
+}
+
+static wstring FormatSavePath(const wstring &path_template, CommandListState *state)
+{
+	wstring path = path_template;
+	wchar_t value[32];
+	SYSTEMTIME time;
+	FILETIME file_time;
+	ULONGLONG ticks;
+	if (path.find(L'%') == wstring::npos)
+		return path;
+
+	GetLocalTime(&time);
+	swprintf_s(value, L"%04u-%02u-%02u", time.wYear, time.wMonth, time.wDay);
+	ReplacePathToken(&path, L"%DATE%", value);
+	swprintf_s(value, L"%02u-%02u-%02u", time.wHour, time.wMinute, time.wSecond);
+	ReplacePathToken(&path, L"%TIME%", value);
+	swprintf_s(value, L"%03u", time.wMilliseconds);
+	ReplacePathToken(&path, L"%MS%", value);
+
+	GetSystemTimeAsFileTime(&file_time);
+	ticks = ((ULONGLONG)file_time.dwHighDateTime << 32) | file_time.dwLowDateTime;
+	swprintf_s(value, L"%06u", (unsigned)((ticks / 10) % 1000000));
+	ReplacePathToken(&path, L"%US%", value);
+	swprintf_s(value, L"%u", G->frame_no);
+	ReplacePathToken(&path, L"%FRAME%", value);
+	swprintf_s(value, L"%u", state->mHackerContext->GetDrawNumber());
+	ReplacePathToken(&path, L"%DRAW%", value);
+
+	if (path.find(L'%') != wstring::npos)
+		for (const auto &variable : command_list_globals) {
+			wstring token = L"%" + variable.first + L"%";
+			swprintf_s(value, L"%.9g", variable.second.fval);
+			ReplacePathToken(&path, token.c_str(), value);
+		}
+	return path;
+}
+
 void FrameAnalysisDumpCommand::run(CommandListState *state)
 {
 	ID3D11Resource *resource = NULL;
@@ -1976,17 +2166,63 @@ void FrameAnalysisDumpCommand::run(CommandListState *state)
 	UINT offset = 0;
 	UINT buf_size = 0;
 	DXGI_FORMAT format = DXGI_FORMAT_UNKNOWN;
+	FrameAnalysisOptions options = analyse_options;
+	wstring filename;
+	bool save = !save_path.empty();
 
-	// Fast exit if frame analysis is currently inactive:
-	if (!G->analyse_frame)
+	if (save && !G->export_command_list_save) {
+		LogOverlayW(LOG_WARNING_ALWAYS,
+			L"save= is disabled; set export_command_list_save=1 in [Rendering] and restart the game\nPath: %ls\nSource: %ls\n",
+			save_path.c_str(), source_ini.c_str());
+		return;
+	}
+	if (!save && !G->analyse_frame)
 		return;
 
 	COMMAND_LIST_LOG(state, "%S\n", ini_line.c_str());
+	if (save) {
+		if (save_limit && save_calls >= save_limit) {
+			LogOverlayW(LOG_WARNING_ALWAYS,
+				L"save= blocked: continuous invocation limit reached\nPath: %ls\nSource: %ls\n",
+				save_path.c_str(), source_ini.c_str());
+			return;
+		}
+		filename = FormatSavePath(save_path, state);
+		if (!SavePathIsSafe(filename, save_directory)) {
+			LogOverlayW(LOG_WARNING_ALWAYS, L"save= blocked invalid path: %ls\nSource: %ls\n",
+				save_path.c_str(), source_ini.c_str());
+			return;
+		}
+
+		if (!save_calls || (G->frame_no != save_last_frame && G->frame_no - save_last_frame != 1))
+			save_calls = 1;
+		else if (save_calls != UINT_MAX)
+			save_calls++;
+		save_last_frame = G->frame_no;
+		if (save_limit && save_calls >= save_limit) {
+			LogOverlayW(LOG_WARNING_ALWAYS,
+				L"save= continuous invocation limit %u reached; further calls are blocked until config reload\nPath: %ls\nSource: %ls\n",
+				save_limit, filename.c_str(), source_ini.c_str());
+		}
+	}
 
 	resource = target.GetResource(state, &view, &stride, &offset, &format, NULL);
 	if (!resource) {
-		COMMAND_LIST_LOG(state, "  No resource to dump\n");
+		COMMAND_LIST_LOG(state, "  No resource to %s\n", save ? "save" : "dump");
 		return;
+	}
+	if (save) {
+		D3D11_RESOURCE_DIMENSION dimension;
+		resource->GetType(&dimension);
+		FrameAnalysisOptions save_format = SaveFormat(filename, dimension);
+		if (save_format == FrameAnalysisOptions::INVALID) {
+			LogOverlayW(LOG_WARNING_ALWAYS,
+				L"save= extension is incompatible with the resource type: %ls\nSource: %ls\n",
+				save_path.c_str(), source_ini.c_str());
+			goto out;
+		}
+		options &= (FrameAnalysisOptions)~(FrameAnalysisOptions::FMT_2D_MASK | FrameAnalysisOptions::FMT_BUF_MASK);
+		options |= save_format;
 	}
 
 	// Fill in any missing info before handing it to frame analysis. The
@@ -1994,16 +2230,25 @@ void FrameAnalysisDumpCommand::run(CommandListState *state)
 	// resources:
 	FillInMissingInfo(target.type, resource, view, &stride, &offset, &buf_size, &format);
 
-	state->mHackerContext->FrameAnalysisDump(resource, analyse_options, target_name.c_str(), format, stride, offset);
+	if (state->mHackerContext->FrameAnalysisDump(resource, options, target_name.c_str(), format, stride, offset,
+			save ? filename.c_str() : NULL)) {
+		if (save)
+			LogOverlayW(LOG_INFO, L"save= %ls\nSource: %ls\n", filename.c_str(), source_ini.c_str());
+	} else if (save) {
+		LogOverlayW(LOG_WARNING_ALWAYS,
+			L"save= failed to submit: %ls\nSource: %ls\n", filename.c_str(), source_ini.c_str());
+	}
 
-	if (resource)
-		resource->Release();
+out:
+	resource->Release();
 	if (view)
 		view->Release();
 }
 
 bool FrameAnalysisDumpCommand::noop(bool post, bool ignore_cto_pre, bool ignore_cto_post)
 {
+	if (!save_path.empty())
+		return false;
 	return (G->hunting == HUNTING_MODE_DISABLED || G->frame_analysis_registered == false);
 }
 
@@ -4213,6 +4458,25 @@ bool CommandArgumentReader::GetFloat(float* out)
 	return true;
 }
 
+bool CommandArgumentReader::GetUInt(unsigned* out)
+{
+	wstring token;
+
+	if (!PeekToken(&token))
+		return false;
+	errno = 0;
+	unsigned long value = wcstoul(token.c_str(), NULL, 10);
+	if (token.find_first_not_of(L"0123456789") != wstring::npos || errno == ERANGE ||
+			value > (std::numeric_limits<unsigned>::max)()) {
+		SetError(L"Invalid unsigned integer: " + token, m_peek_start_pos);
+		return false;
+	}
+	*out = (unsigned)value;
+	ConsumeToken();
+	LogDebugW(L"  Unsigned integer: '%ls'\n", token.c_str());
+	return true;
+}
+
 bool CommandArgumentReader::GetExpression(unique_ptr<CommandListExpression>* out)
 {
 	wstring token;
@@ -4278,6 +4542,11 @@ bool CommandArgumentReader::ConsumeSeparator(SeparatorMode separator_mode)
 
 	SetError(L"Internal parser error", m_pos);
 	return false;
+}
+
+bool CommandArgumentReader::HasMore() const
+{
+	return m_input.find_first_not_of(L" \t\r\n", m_pos) != wstring::npos;
 }
 
 bool CommandArgumentReader::Finished()

--- a/DirectX11/CommandList.h
+++ b/DirectX11/CommandList.h
@@ -1609,6 +1609,12 @@ public:
 	ResourceCopyTarget target;
 	wstring target_name;
 	FrameAnalysisOptions analyse_options;
+	wstring save_path;
+	wstring save_directory;
+	wstring source_ini;
+	unsigned save_limit = 0;
+	unsigned save_calls = 0;
+	unsigned save_last_frame = 0;
 
 	void run(CommandListState*) override;
 	bool noop(bool post, bool ignore_cto_pre, bool ignore_cto_post) override;
@@ -1728,9 +1734,11 @@ public:
 	bool GetVariable(CommandListVariable*& out, bool is_source, PeekMode mode = PeekMode::Token);
 	bool GetTarget(ResourceCopyTarget* out, bool is_source, PeekMode mode = PeekMode::Token, bool validate = true);
 	bool GetFloat(float* out);
+	bool GetUInt(unsigned* out);
 	bool GetExpression(unique_ptr<CommandListExpression>* out);
 
 	bool ConsumeSeparator(SeparatorMode separator_mode);
+	bool HasMore() const;
 	bool Finished();
 
 	const wstring& Error() const { return m_error; }

--- a/DirectX11/FrameAnalysis.cpp
+++ b/DirectX11/FrameAnalysis.cpp
@@ -504,6 +504,16 @@ ID3D11DeviceContext* FrameAnalysisContext::GetDumpingContext()
 	return GetPassThroughOrigContext1();
 }
 
+bool FrameAnalysisContext::abort_dump()
+{
+	if (analyse_options & FrameAnalysisOptions::FILENAME_EXACT)
+		return false;
+	if (!G->analyse_frame)
+		return true;
+	DispatchInputEvents(GetHackerDevice());
+	return !G->analyse_frame;
+}
+
 void FrameAnalysisContext::Dump2DResourceImmediateCtx(ID3D11Texture2D *staging,
 		wstring filename, D3D11_TEXTURE2D_DESC *orig_desc, DXGI_FORMAT format)
 {
@@ -512,6 +522,25 @@ void FrameAnalysisContext::Dump2DResourceImmediateCtx(ID3D11Texture2D *staging,
 	wstring save_filename;
 	wchar_t *wic_ext = L".jpg";
 	size_t ext, save_ext;
+
+	if (analyse_options & FrameAnalysisOptions::FILENAME_EXACT) {
+		const wchar_t *extension = wcsrchr(filename.c_str(), L'.');
+		GUID container = GUID_ContainerFormatJpeg;
+
+		EnsureCOM();
+		if (!_wcsicmp(extension, L".dds"))
+			hr = DirectX::SaveDDSTextureToFile(GetDumpingContext(), staging, filename.c_str());
+		else {
+			if (!_wcsicmp(extension, L".png"))
+				container = GUID_ContainerFormatPng;
+			else if (!_wcsicmp(extension, L".bmp"))
+				container = GUID_ContainerFormatBmp;
+			hr = DirectX::SaveWICTextureToFile(GetDumpingContext(), staging, container, filename.c_str());
+		}
+		if (FAILED(hr))
+			FALogErr(L"Failed to save Texture2D %ls: 0x%x\n", filename.c_str(), hr);
+		return;
+	}
 
 	save_filename = dedupe_tex2d_filename(staging, orig_desc, dedupe_filename, MAX_PATH, filename.c_str(), format);
 
@@ -769,7 +798,7 @@ void FrameAnalysisContext::dedupe_buf_filename_txt(const wchar_t *bin_filename,
  * try to use the reflection information in the shaders to add names and
  * correct types.
  */
-void FrameAnalysisContext::DumpBufferTxt(wchar_t *filename, D3D11_MAPPED_SUBRESOURCE *map,
+void FrameAnalysisContext::DumpBufferTxt(const wchar_t *filename, D3D11_MAPPED_SUBRESOURCE *map,
 		UINT size, char type, int idx, UINT stride, UINT offset)
 {
 	FILE *fd = NULL;
@@ -1602,12 +1631,9 @@ void FrameAnalysisContext::dump_deferred_resources(ID3D11CommandList *command_li
 	} catch (std::out_of_range) {}
 	if (deferred_buffers) {
 		for (FrameAnalysisDeferredDumpBufferArgs &i : *deferred_buffers) {
-			// Process key inputs to allow user to abort long running frame analysis sessions:
-			DispatchInputEvents(GetHackerDevice());
-			if (!G->analyse_frame)
-				break;
-
 			this->analyse_options = i.analyse_options;
+			if (abort_dump())
+				continue;
 			DumpBufferImmediateCtx(i.staging.Get(), &i.orig_desc,
 					i.filename, i.buf_type_mask, i.idx,
 					i.ib_fmt, i.stride, i.offset, i.first,
@@ -1622,12 +1648,9 @@ void FrameAnalysisContext::dump_deferred_resources(ID3D11CommandList *command_li
 	} catch (std::out_of_range) {}
 	if (deferred_tex2d) {
 		for (FrameAnalysisDeferredDumpTex2DArgs &i : *deferred_tex2d) {
-			// Process key inputs to allow user to abort long running frame analysis sessions:
-			DispatchInputEvents(GetHackerDevice());
-			if (!G->analyse_frame)
-				break;
-
 			this->analyse_options = i.analyse_options;
+			if (abort_dump())
+				continue;
 			Dump2DResourceImmediateCtx(i.staging.Get(), i.filename, &i.orig_desc, i.format);
 		}
 	}
@@ -1735,6 +1758,21 @@ void FrameAnalysisContext::DumpBufferImmediateCtx(ID3D11Buffer *staging, D3D11_B
 		FALogErr(L"DumpBuffer failed to map staging resource: 0x%x\n", hr);
 		return;
 	}
+	if (analyse_options & FrameAnalysisOptions::FILENAME_EXACT) {
+		if (analyse_options & FrameAnalysisOptions::FMT_BUF_BIN) {
+			err = wfopen_ensuring_access(&fd, filename.c_str(), L"wb");
+			if (fd) {
+				fwrite(map.pData, 1, orig_desc->ByteWidth, fd);
+				fclose(fd);
+			} else {
+				FALogErr(L"Unable to create %ls: %u\n", filename.c_str(), err);
+			}
+		} else {
+			DumpBufferTxt(filename.c_str(), &map,
+				orig_desc->ByteWidth, '?', -1, stride, offset);
+		}
+		goto out_unmap;
+	}
 
 	dedupe_buf_filename(staging, orig_desc, &map, bin_filename, MAX_PATH);
 
@@ -1823,11 +1861,8 @@ void FrameAnalysisContext::DumpBuffer(ID3D11Buffer *buffer, wchar_t *filename,
 	ID3D11Buffer *staging = NULL;
 	HRESULT hr;
 
-	// Process key inputs to allow user to abort long running frame
-	// analysis sessions (this case is specifically for dump_vb and dump_ib
-	// which bypasses DumpResource()):
-	DispatchInputEvents(GetHackerDevice());
-	if (!G->analyse_frame)
+	// dump_vb and dump_ib bypass DumpResource(), so handle aborts here.
+	if (abort_dump())
 		return;
 
 	buffer->GetDesc(&desc);
@@ -1867,9 +1902,7 @@ void FrameAnalysisContext::DumpResource(ID3D11Resource *resource, wchar_t *filen
 {
 	D3D11_RESOURCE_DIMENSION dim;
 
-	// Process key inputs to allow user to abort long running frame analysis sessions:
-	DispatchInputEvents(GetHackerDevice());
-	if (!G->analyse_frame)
+	if (abort_dump())
 		return;
 
 	resource->GetType(&dim);
@@ -1901,22 +1934,18 @@ void FrameAnalysisContext::DumpResource(ID3D11Resource *resource, wchar_t *filen
 	}
 }
 
-static BOOL CreateDeferredFADirectory(LPCWSTR path)
+static BOOL EnsureDirectory(LPCWSTR path)
 {
-	DWORD err;
+	DWORD attributes, err;
 
-	// Deferred contexts don't have an opportunity to create their
-	// dumps directory earlier, so do so now:
-
-	if (!CreateDirectoryEnsuringAccess(path)) {
-		err = GetLastError();
-		if (err != ERROR_ALREADY_EXISTS) {
-			LogInfoW(L"Error creating deferred frame analysis directory: %i\n", err);
-			return FALSE;
-		}
-	}
-
-	return TRUE;
+	if (CreateDirectoryEnsuringAccess(path))
+		return TRUE;
+	err = GetLastError();
+	attributes = GetFileAttributes(path);
+	if (attributes != INVALID_FILE_ATTRIBUTES && attributes & FILE_ATTRIBUTE_DIRECTORY)
+		return TRUE;
+	LogInfoW(L"Error creating directory: %i\n", err);
+	return FALSE;
 }
 
 void FrameAnalysisContext::get_deduped_dir(wchar_t *path, size_t size)
@@ -1945,7 +1974,7 @@ HRESULT FrameAnalysisContext::FrameAnalysisFilename(wchar_t *filename, size_t si
 	StringCchPrintfExW(filename, size, &pos, &rem, NULL, L"%ls\\", G->ANALYSIS_PATH);
 	if (GetPassThroughOrigContext1()->GetType() == D3D11_DEVICE_CONTEXT_DEFERRED) {
 		StringCchPrintfExW(pos, rem, &pos, &rem, NULL, L"ctx-0x%p\\", this);
-		if (!CreateDeferredFADirectory(filename))
+		if (!EnsureDirectory(filename))
 			return E_FAIL;
 	}
 
@@ -2054,7 +2083,7 @@ HRESULT FrameAnalysisContext::FrameAnalysisFilenameResource(wchar_t *filename, s
 	StringCchPrintfExW(filename, size, &pos, &rem, NULL, L"%ls\\", G->ANALYSIS_PATH);
 	if (GetPassThroughOrigContext1()->GetType() == D3D11_DEVICE_CONTEXT_DEFERRED) {
 		StringCchPrintfExW(pos, rem, &pos, &rem, NULL, L"ctx-0x%p\\", this);
-		if (!CreateDeferredFADirectory(filename))
+		if (!EnsureDirectory(filename))
 			return E_FAIL;
 	}
 
@@ -2949,13 +2978,46 @@ void FrameAnalysisContext::FrameAnalysisAfterUpdate(ID3D11Resource *resource)
 	_FrameAnalysisAfterUpdate(resource, FrameAnalysisOptions::DUMP_ON_UPDATE, L"update");
 }
 
-void FrameAnalysisContext::FrameAnalysisDump(ID3D11Resource *resource, FrameAnalysisOptions options,
-		const wchar_t *target, DXGI_FORMAT format, UINT stride, UINT offset)
+static bool CreateSaveDirectories(const wchar_t *filename)
+{
+	wchar_t path[MAX_PATH];
+	wchar_t *end, *p;
+	DWORD attributes;
+
+	if (wcscpy_s(path, filename))
+		return false;
+	end = wcsrchr(path, L'\\');
+	if (!end)
+		return false;
+	*end = 0;
+	p = PathSkipRootW(path);
+	if (!p)
+		return false;
+	attributes = GetFileAttributes(path);
+	if (attributes != INVALID_FILE_ATTRIBUTES && attributes & FILE_ATTRIBUTE_DIRECTORY)
+		return true;
+
+	for (; *p; p++) {
+		if (*p != L'\\')
+			continue;
+		*p = 0;
+		if (!EnsureDirectory(path))
+			return false;
+		*p = L'\\';
+	}
+	return EnsureDirectory(path);
+}
+
+bool FrameAnalysisContext::FrameAnalysisDump(ID3D11Resource *resource, FrameAnalysisOptions options,
+		const wchar_t *target, DXGI_FORMAT format, UINT stride, UINT offset,
+		const wchar_t *exact_filename)
 {
 	wchar_t filename[MAX_PATH];
-	HRESULT hr;
+	HRESULT hr = S_OK;
 
 	analyse_options = options;
+	if (exact_filename)
+		analyse_options |= FrameAnalysisOptions::FILENAME_EXACT;
 
 	if (!(analyse_options & FrameAnalysisOptions::DEFRD_CTX_MASK) &&
 	   (GetPassThroughOrigContext1()->GetType() != D3D11_DEVICE_CONTEXT_IMMEDIATE)) {
@@ -2971,17 +3033,24 @@ void FrameAnalysisContext::FrameAnalysisDump(ID3D11Resource *resource, FrameAnal
 	analyse_options &= (FrameAnalysisOptions)~FrameAnalysisOptions::STEREO_MASK;
 	analyse_options |= FrameAnalysisOptions::MONO;
 
-	set_default_dump_formats(false);
+	if (!exact_filename)
+		set_default_dump_formats(false);
+	else if (wcscpy_s(filename, exact_filename) || !CreateSaveDirectories(filename)) {
+		FALogErr(L"Unable to create save path: %ls\n", exact_filename);
+		return false;
+	}
 
 	EnterCriticalSectionPretty(&G->mCriticalSection);
 
 	setlocale(LC_CTYPE, "en_US.UTF-8");
 
-	hr = FrameAnalysisFilenameResource(filename, MAX_PATH, target, resource, false);
-	if (FAILED(hr)) {
-		// If the ini section and resource name makes the filename too
-		// long, try again without them:
-		hr = FrameAnalysisFilenameResource(filename, MAX_PATH, L"...", resource, false);
+	if (!exact_filename) {
+		hr = FrameAnalysisFilenameResource(filename, MAX_PATH, target, resource, false);
+		if (FAILED(hr)) {
+			// If the ini section and resource name makes the filename too
+			// long, try again without them:
+			hr = FrameAnalysisFilenameResource(filename, MAX_PATH, L"...", resource, false);
+		}
 	}
 	if (SUCCEEDED(hr))
 		DumpResource(resource, filename, analyse_options, -1, format, stride, offset);
@@ -2990,7 +3059,9 @@ void FrameAnalysisContext::FrameAnalysisDump(ID3D11Resource *resource, FrameAnal
 
 	LeaveCriticalSection(&G->mCriticalSection);
 
-	non_draw_call_dump_counter++;
+	if (!exact_filename)
+		non_draw_call_dump_counter++;
+	return SUCCEEDED(hr);
 }
 
 // -----------------------------------------------------------------------------------------------

--- a/DirectX11/FrameAnalysis.h
+++ b/DirectX11/FrameAnalysis.h
@@ -125,7 +125,7 @@ private:
 	HRESULT CreateStagingResource(ID3D11Texture2D **resource,
 		D3D11_TEXTURE2D_DESC desc, bool msaa, DXGI_FORMAT format);
 
-	void DumpBufferTxt(wchar_t *filename, D3D11_MAPPED_SUBRESOURCE *map,
+	void DumpBufferTxt(const wchar_t *filename, D3D11_MAPPED_SUBRESOURCE *map,
 			UINT size, char type, int idx, UINT stride, UINT offset);
 	void DumpVBTxt(wchar_t *filename, D3D11_MAPPED_SUBRESOURCE *map,
 			UINT size, int idx, UINT stride, UINT offset,
@@ -156,6 +156,7 @@ private:
 	void DumpResource(ID3D11Resource *resource, wchar_t *filename,
 			FrameAnalysisOptions buf_type_mask, int idx, DXGI_FORMAT format,
 			UINT stride, UINT offset);
+	bool abort_dump();
 	void _DumpCBs(char shader_type, bool compute,
 		ID3D11Buffer *buffers[D3D11_COMMONSHADER_CONSTANT_BUFFER_API_SLOT_COUNT]);
 	void _DumpTextures(char shader_type, bool compute,
@@ -233,8 +234,9 @@ public:
 #define FrameAnalysisLogNoNL FrameAnalysisLog
 
 	void FrameAnalysisTrigger(FrameAnalysisOptions new_options) override;
-	void FrameAnalysisDump(ID3D11Resource *resource, FrameAnalysisOptions options,
-		const wchar_t *target, DXGI_FORMAT format, UINT stride, UINT offset) override;
+	bool FrameAnalysisDump(ID3D11Resource *resource, FrameAnalysisOptions options,
+		const wchar_t *target, DXGI_FORMAT format, UINT stride, UINT offset,
+		const wchar_t *exact_filename) override;
 
 	/*** IUnknown methods ***/
 

--- a/DirectX11/HackerContext.cpp
+++ b/DirectX11/HackerContext.cpp
@@ -54,7 +54,8 @@ HackerContext* HackerContextFactory(ID3D11Device1 *pDevice1, ID3D11DeviceContext
 	// because frame analysis resource dumping still has some dependencies
 	// on stat collection), so G->hunting is already a pre-requisite for
 	// frame analysis:
-	if (G->hunting || gLogDebug) {
+	// Command-list save reuses the same dumping backend without enabling analysis.
+	if (G->hunting || gLogDebug || G->export_command_list_save) {
 		LogInfo("  Creating FrameAnalysisContext\n");
 		return new FrameAnalysisContext(pDevice1, pContext1);
 	}

--- a/DirectX11/HackerContext.h
+++ b/DirectX11/HackerContext.h
@@ -244,8 +244,9 @@ public:
 	// public to allow CommandList access
 	virtual void FrameAnalysisLog(char *fmt, ...) {};
 	virtual void FrameAnalysisTrigger(FrameAnalysisOptions new_options) {};
-	virtual void FrameAnalysisDump(ID3D11Resource *resource, FrameAnalysisOptions options,
-		const wchar_t *target, DXGI_FORMAT format, UINT stride, UINT offset) {};
+	virtual bool FrameAnalysisDump(ID3D11Resource *resource, FrameAnalysisOptions options,
+		const wchar_t *target, DXGI_FORMAT format, UINT stride, UINT offset,
+		const wchar_t *exact_filename = NULL) { return false; };
 
 	unsigned GetDrawNumber() const { return draw_number; };
 	unsigned GetDispatchNumber() const { return dispatch_number; };

--- a/DirectX11/IniHandler.cpp
+++ b/DirectX11/IniHandler.cpp
@@ -324,6 +324,11 @@ static bool _get_section_path(IniSections *custom_ini_sections, const wchar_t *s
 	return (!ret->empty());
 }
 
+bool get_section_path(const wchar_t *section, wstring *ret)
+{
+	return _get_section_path(&ini_sections, section, ret);
+}
+
 static size_t get_section_namespace_endpos(const wchar_t *section)
 {
 	const wchar_t *section_prefix;
@@ -4473,6 +4478,23 @@ void LoadConfigFile()
 		enable_lock_dependency_checks();
 
 	G->gShowWarnings = GetIniBool(L"Logging", L"show_warnings", true, NULL);
+
+	// Read before includes so mods cannot enable save I/O.
+	G->export_command_list_save = GetIniBool(L"Rendering", L"export_command_list_save", false, NULL);
+	G->export_command_list_save_count = 100;
+	const wstring *save_count = GetIniWstring(L"Rendering", L"export_command_list_save_count");
+	if (save_count) {
+		errno = 0;
+		unsigned long long value = wcstoull(save_count->c_str(), NULL, 10);
+		if (save_count->empty() || save_count->find_first_not_of(L"0123456789") != wstring::npos ||
+				errno == ERANGE || value > UINT_MAX) {
+			LogOverlayW(LOG_WARNING_ALWAYS,
+				L"export_command_list_save_count must be a non-negative integer; using 100\n - [Rendering]\n");
+		} else {
+			G->export_command_list_save_count = (unsigned)value;
+			LogInfoW(L"  export_command_list_save_count=%u\n", G->export_command_list_save_count);
+		}
+	}
 
 	// Allows to delay DLL initialization by given ms count
 	G->gDllInitializationDelay = GetIniInt(L"System", L"dll_initialization_delay", 0, NULL);

--- a/DirectX11/IniHandler.h
+++ b/DirectX11/IniHandler.h
@@ -77,5 +77,6 @@ bool ParseBinaryLiterals(const wstring& input, size_t start, uint64_t& out, size
 bool get_namespaced_section_name_lower(const wstring *section, const wstring *ini_namespace, wstring *ret);
 bool get_section_namespace(const wchar_t *section, wstring *ret);
 wstring get_namespaced_var_name_lower(const wstring var, const wstring *ini_namespace);
+bool get_section_path(const wchar_t *section, wstring *ret);
 
 CommandListVariable* RegisterGlobalVariable(wstring& name, float* fval, VariableFlags flags);

--- a/DirectX11/Overlay.cpp
+++ b/DirectX11/Overlay.cpp
@@ -52,6 +52,7 @@ struct LogLevelParams {
 struct LogLevelParams log_levels[] = {
 	{ DirectX::Colors::Red,       20000, false, &Overlay::mFontNotifications }, // DIRE
 	{ DirectX::Colors::OrangeRed, 10000, false, &Overlay::mFontNotifications }, // WARNING
+	{ DirectX::Colors::OrangeRed, 10000, false, &Overlay::mFontNotifications }, // WARNING_ALWAYS
 	{ DirectX::Colors::OrangeRed, 10000, false, &Overlay::mFontProfiling     }, // WARNING_MONOSPACE
 	{ DirectX::Colors::Orange,     5000, false, &Overlay::mFontNotifications }, // NOTICE
 	{ DirectX::Colors::LimeGreen,  2000, false, &Overlay::mFontNotifications }, // INFO
@@ -869,9 +870,31 @@ void ClearNotices()
 	LeaveCriticalSection(&notices.lock);
 }
 
+static void AddOverlayNotice(LogLevel level, const wchar_t *message)
+{
+	std::vector<OverlayNotice> &level_notices = notices.notices[level];
+	OverlayNotice *duplicate = NULL;
+
+	EnterCriticalSectionPretty(&notices.lock);
+
+	if (level == LOG_WARNING_ALWAYS)
+		for (OverlayNotice &notice : level_notices)
+			if (notice.message == message) {
+				duplicate = &notice;
+				break;
+			}
+	if (duplicate)
+		duplicate->timestamp = 0;
+	else
+		level_notices.emplace_back(message);
+	has_notice = true;
+
+	LeaveCriticalSection(&notices.lock);
+}
+
 void LogOverlayW(LogLevel level, wchar_t *fmt, ...)
 {
-	if (!G->gShowWarnings && level != LOG_INFO) {
+	if (!G->gShowWarnings && level != LOG_INFO && level != LOG_WARNING_ALWAYS) {
 		return;
 	}
 
@@ -887,12 +910,7 @@ void LogOverlayW(LogLevel level, wchar_t *fmt, ...)
 	// cares if it gets cut off somewhere off screen anyway?
 	_vsnwprintf_s(msg, maxstring, _TRUNCATE, fmt, ap);
 
-	EnterCriticalSectionPretty(&notices.lock);
-
-	notices.notices[level].emplace_back(msg);
-	has_notice = true;
-
-	LeaveCriticalSection(&notices.lock);
+	AddOverlayNotice(level, msg);
 
 	va_end(ap);
 }
@@ -904,7 +922,7 @@ void LogOverlayW(LogLevel level, wchar_t *fmt, ...)
 // format string correctly and convert the result to a wide string.
 void LogOverlay(LogLevel level, char *fmt, ...)
 {
-	if (!G->gShowWarnings && level != LOG_INFO) {
+	if (!G->gShowWarnings && level != LOG_INFO && level != LOG_WARNING_ALWAYS) {
 		return;
 	}
 
@@ -923,12 +941,7 @@ void LogOverlay(LogLevel level, char *fmt, ...)
 		_vsnprintf_s(amsg, maxstring, _TRUNCATE, fmt, ap);
 		mbstowcs(wmsg, amsg, maxstring);
 
-		EnterCriticalSectionPretty(&notices.lock);
-
-		notices.notices[level].emplace_back(wmsg);
-		has_notice = true;
-
-		LeaveCriticalSection(&notices.lock);
+		AddOverlayNotice(level, wmsg);
 	}
 
 	va_end(ap);

--- a/DirectX11/Overlay.h
+++ b/DirectX11/Overlay.h
@@ -20,6 +20,7 @@ class HackerSwapChain;
 enum LogLevel {
 	LOG_DIRE,
 	LOG_WARNING,
+	LOG_WARNING_ALWAYS, // Safety notices unaffected by show_warnings
 	LOG_WARNING_MONOSPACE,
 	LOG_NOTICE,
 	LOG_INFO,

--- a/DirectX11/globals.h
+++ b/DirectX11/globals.h
@@ -183,6 +183,7 @@ enum class FrameAnalysisOptions {
 	DEFRD_CTX_DELAY = 0x00800000,
 	DEFRD_CTX_MASK  = 0x00c00000,
 	SYMLINK         = 0x01000000,
+	FILENAME_EXACT  = 0x02000000, // Internal: save to the supplied path without deduplication
 	DEPRECATED      = (signed)0x80000000,
 };
 SENSIBLE_ENUM(FrameAnalysisOptions);
@@ -471,6 +472,8 @@ struct Globals
 	int texture_hash_version;
 	int EXPORT_HLSL;		// 0=off, 1=HLSL only, 2=HLSL+OriginalASM, 3= HLSL+OriginalASM+recompiledASM
 	bool EXPORT_SHADERS, EXPORT_FIXED, EXPORT_BINARY, CACHE_SHADERS, SCISSOR_DISABLE;
+	bool export_command_list_save;
+	unsigned export_command_list_save_count;
 	int track_texture_updates;
 	bool assemble_signature_comments;
 	bool disassemble_undecipherable_custom_data;
@@ -685,6 +688,8 @@ struct Globals
 		EXPORT_FIXED(false),
 		EXPORT_BINARY(false),
 		CACHE_SHADERS(false),
+		export_command_list_save(false),
+		export_command_list_save_count(100),
 		DumpUsage(false),
 		ENABLE_TUNE(false),
 		gTuneStep(0.001f),


### PR DESCRIPTION
alternative dump 

example:
;this will save dump inside *migoto_folder*\Custom\capture.dds
post/pre save = [ResourceExample/ps-tN/so0/vb and other that could be handled with dump =] [.\Custom\capture.dds]
;this will save dump resource from .ini file launched path
post/pre save = [ResourceExample/ps-tN/so0/vb and other that could be handled with dump =] [Custom\capture.dds]
;So we get something like *migoto_folder*\Mods\EasyScreenshot\ >>> Custom\capture.dds


Custom vars inside resource name:
%DATE% %TIME% %MS% %US% %FRAME% %DRAW%

NON-ASCII path is also acceptable, for example:

<img width="738" height="637" alt="image" src="https://github.com/user-attachments/assets/4d7e6073-05f3-4887-86fb-ae02c7587cfc" />
<img width="1657" height="951" alt="image" src="https://github.com/user-attachments/assets/6f75ee85-baf6-42d8-ba0a-1621ec9199cb" />

Usage cases i found:
Screenshots inside one folder instead bunch of AnalyseFrame-
use as save function with buffers instead of making 67000 variables that will flood inside d3dx_user.ini
and maybe other


Save functionality >>>

Whitelisted extensions:
.dds, .png, .jpg, .jpeg, .bmp, .txt, .buf, .bin, .ib, .vb

I also tested various scenarios and added restrictions.
1) You cannot go beyond the specified path .../
2) You cannot write to the root directory 3dmigoto ./frame.dds
3) It is allowed to create files that won’t cause conflicts
*migoto_path*/CustomFolderIfItDoesntExistItWillBeCreated/frame.dds
4) or relative to where the mod itself was launched
5) The only way to start writing directly to the Mods folder is in a scenario where the INI file was placed directly in the Mods folder; based on my tests, this is the only case where it works.


Translated with [DeepL.com](https://www.deepl.com/?utm_campaign=product&utm_source=web_translator&utm_medium=web&utm_content=copy_free_translation) (free version)

Auto-tests i've used:
```
[CommandListSaveScreen]
post save = ResourceImage .\Screenshots\frame.dds
post save = ResourceImage .\Screenshots\sub\frame.png
post save = ResourceImage .\Custom\capture.dds
post save = ResourceImage .\Custom\capture2.dds
post save = ResourceImage .\DataBuffer\test.buf
post save = ResourceImage .\DataBuffer\test.raw
post save = ResourceImage .\DataBuffer\test.bin
post save = ResourceImage .\Logs\debug.txt
post save = ResourceImage .\Logs\data.json
post save = ResourceImage .\Logs\records.csv
post save = ResourceImage output.dds
post save = ResourceImage subfolder\output.png
post save = ResourceImage sub\decal.buf
post save = ResourceImage logs\mod.txt
post save = ResourceImage .\frame.dds
post save = ResourceImage .\direct.png
post save = ResourceImage .\data.buf
post save = ResourceImage .\Screenshots\..\..\Windows\System32\cmd.exe
post save = ResourceImage .\Screenshots\..\frame.png
post save = ResourceImage .\Screenshots\..\..\unsafe.png
post save = ResourceImage .\Screenshots\..\..\Mods\OtherMod\hack.dds
post save = ResourceImage C:\Users\Public\hack.dds
post save = ResourceImage D:\Games\Genshin\capture.dds
post save = ResourceImage \Screenshots\hack.dds
post save = ResourceImage /Screenshots/hack.dds
post save = ResourceImage .\core\hack.dds
post save = ResourceImage .\ShaderFixes\hack.dds
post save = ResourceImage .\ShaderCache\hack.dds
post save = ResourceImage .\ShaderFromGame\hack.dds
post save = ResourceImage .\Mods\hack.dds
post save = ResourceImage .\Mods\OtherMod\hack.dds
post save = ResourceImage .\Screenshots\exploit.dll
post save = ResourceImage .\Screenshots\exploit.exe
post save = ResourceImage .\Screenshots\exploit.bat
post save = ResourceImage .\Screenshots\exploit.cmd
post save = ResourceImage .\Screenshots\exploit.vbs
post save = ResourceImage .\Screenshots\exploit.sh
post save = ResourceImage .\Screenshots\exploit.py
post save = ResourceImage .\Screenshots\exploit.ini
```

UPDATE:

`save=` is opt-in through `export_command_list_save`.
Continuous calls: 100 by default, `0` for unlimited.
Overlay shows path/source for calls, disabled state and limit hits.
Runtime path checks also block reparse points and Windows path tricks.