### PR TITLE
New Performance Monitor Mode -> Variables Display

### DIFF
--- a/DirectX11/CommandList.cpp
+++ b/DirectX11/CommandList.cpp
@@ -30,6 +30,9 @@ std::unordered_set<CommandList*> command_lists_profiling;
 std::unordered_set<CommandListCommand*> command_lists_cmd_profiling;
 std::vector<std::shared_ptr<CommandList>> dynamically_allocated_command_lists;
 
+std::vector<VariableEntry> variableList;
+std::map<std::wstring, std::vector<VariableEntry*>> variable_groups;
+std::vector<std::wstring> namespace_list;
 
 // Adds consistent "3DMigoto" prefix to frame analysis log with appropriate
 // level of indentation for the current recursion level. Using a

--- a/DirectX11/CommandList.cpp
+++ b/DirectX11/CommandList.cpp
@@ -30,9 +30,24 @@ std::unordered_set<CommandList*> command_lists_profiling;
 std::unordered_set<CommandListCommand*> command_lists_cmd_profiling;
 std::vector<std::shared_ptr<CommandList>> dynamically_allocated_command_lists;
 
+// Values Viewer
+
+// Variables
+
 std::vector<VariableEntry> variableList;
 std::map<std::wstring, std::vector<VariableEntry*>> variable_groups;
 std::vector<std::wstring> namespace_list;
+
+// Custom Resources
+
+std::vector<CustomResourceEntry> customResourceList;
+std::map<std::wstring, std::vector<CustomResourceEntry*>> custom_resource_groups;
+std::vector<std::wstring> custom_resource_namespace_list;
+
+// Pools
+
+std::vector<std::wstring> resource_pool_list;
+
 
 // Adds consistent "3DMigoto" prefix to frame analysis log with appropriate
 // level of indentation for the current recursion level. Using a

--- a/DirectX11/CommandList.h
+++ b/DirectX11/CommandList.h
@@ -122,6 +122,18 @@ typedef std::unordered_map<std::wstring, class CommandListVariable> CommandListV
 extern CommandListVariables command_list_globals;
 extern std::vector<CommandListVariable*> persistent_variables;
 
+struct VariableEntry
+{
+    std::wstring name;
+    std::wstring var_namespace;
+
+    CommandListVariable* variable;
+};
+
+extern std::vector<VariableEntry> variableList;
+extern std::map<std::wstring, std::vector<VariableEntry*>> variable_groups;
+extern std::vector<std::wstring> namespace_list;
+
 // The scope object is used to declare local variables in a command list. The
 // multiple levels are to isolate variables declared inside if blocks from
 // being accessed in a parent or sibling scope, while allowing variables

--- a/DirectX11/CommandList.h
+++ b/DirectX11/CommandList.h
@@ -149,6 +149,10 @@ typedef std::unordered_map<std::wstring, class CommandListVariable> CommandListV
 extern CommandListVariables command_list_globals;
 extern std::vector<CommandListVariable*> persistent_variables;
 
+// Values Viewer
+
+// Variables
+
 struct VariableEntry
 {
     std::wstring name;
@@ -160,6 +164,25 @@ struct VariableEntry
 extern std::vector<VariableEntry> variableList;
 extern std::map<std::wstring, std::vector<VariableEntry*>> variable_groups;
 extern std::vector<std::wstring> namespace_list;
+
+// Custom Resources
+
+struct CustomResourceEntry
+{
+	std::wstring name;
+	std::wstring resource_namespace;
+
+	CustomResource* resource;
+};
+
+extern std::vector<CustomResourceEntry> customResourceList;
+extern std::map<std::wstring, std::vector<CustomResourceEntry*>> custom_resource_groups;
+extern std::vector<std::wstring> custom_resource_namespace_list;
+
+// Pools
+
+extern std::vector<std::wstring> resource_pool_list;
+
 
 // The scope object is used to declare local variables in a command list. The
 // multiple levels are to isolate variables declared inside if blocks from
@@ -681,6 +704,11 @@ public:
 
 	void ResetElements();
 	void ResetPool(bool reset_elements = true);
+
+	const std::vector<PoolElement>& GetElements() const
+	{
+		return elements;
+	}
 
 private:
 	void InitializeResource(size_t pool_index);

--- a/DirectX11/Hunting.cpp
+++ b/DirectX11/Hunting.cpp
@@ -24,6 +24,8 @@
 //  DWORD type for the Write calls.  These are writing 256 byte strings, so there is never a chance that it 
 //  will lose data, so rather than do anything heroic here, I'm just doing type casts on the strlen function.
 
+Profiling::VariableColumn* selected_column;
+
 DWORD castStrLen(const char* string)
 {
 	return (DWORD)strlen(string);
@@ -1296,6 +1298,9 @@ static void AnalysePerf(HackerDevice *device, void *private_data)
 
 	if (Profiling::mode == Profiling::Mode::INVALID)
 		Profiling::mode = Profiling::Mode::NONE;
+	
+	if (Profiling::mode == Profiling::Mode::COMMAND_LIST_VARIABLES)
+		selected_column = &Profiling::variable_columns[Profiling::active_column];
 
 	Profiling::text.clear();
 	Profiling::clear();
@@ -1310,6 +1315,81 @@ static void FreezePerf(HackerDevice *device, void *private_data)
 
 	if (Profiling::freeze)
 		LogInfoW(L"%s", Profiling::text.c_str());
+}
+
+static void CycleNamespaceColumn(HackerDevice* device, void* private_data)
+{
+	if (Profiling::mode == Profiling::Mode::COMMAND_LIST_VARIABLES) {
+		Profiling::active_column++;
+
+		if (Profiling::active_column > 5)
+			Profiling::active_column = 0;
+
+		selected_column = &Profiling::variable_columns[Profiling::active_column];
+
+		Profiling::text.clear();
+		Profiling::clear();
+	}
+}
+
+static void NextNamespace(HackerDevice* device, void* private_data)
+{
+	if (Profiling::mode == Profiling::Mode::COMMAND_LIST_VARIABLES) {
+		selected_column->namespace_index++;
+
+		if (selected_column->namespace_index >= namespace_list.size())
+			selected_column->namespace_index = -1;
+
+		Profiling::text.clear();
+		Profiling::clear();
+	}
+}
+
+static void PreviousNamespace(HackerDevice* device, void* private_data)
+{
+	if (Profiling::mode == Profiling::Mode::COMMAND_LIST_VARIABLES) {
+		selected_column->namespace_index--;
+
+		if (selected_column->namespace_index < -1)
+			selected_column->namespace_index = namespace_list.size()-1;
+
+		Profiling::text.clear();
+		Profiling::clear();
+	}
+}
+
+static void NextVar(HackerDevice* device, void* private_data)
+{
+	if (Profiling::mode == Profiling::Mode::COMMAND_LIST_VARIABLES) {
+
+		if (variable_groups[namespace_list[selected_column->namespace_index]].size() < Profiling::visible_rows || selected_column->namespace_index == -1)
+			return;
+
+		selected_column->scroll_offset++;
+
+		if (selected_column->scroll_offset > (variable_groups[namespace_list[selected_column->namespace_index]].size() - Profiling::visible_rows))
+			selected_column->scroll_offset = 0;
+
+		Profiling::text.clear();
+		Profiling::clear();
+	}
+}
+
+static void PreviousVar(HackerDevice* device, void* private_data)
+{
+	if (Profiling::mode == Profiling::Mode::COMMAND_LIST_VARIABLES) {
+
+		if (variable_groups[namespace_list[selected_column->namespace_index]].size() < Profiling::visible_rows || selected_column->namespace_index == -1)
+			return;
+
+		selected_column->scroll_offset--;
+
+		if (selected_column->scroll_offset < 0)
+			selected_column->scroll_offset = variable_groups[namespace_list[selected_column->namespace_index]].size() - Profiling::visible_rows;
+
+		Profiling::text.clear();
+		Profiling::clear();
+	}
 }
 
 static void DisableDeferred(HackerDevice *device, void *private_data)
@@ -1977,6 +2057,13 @@ void ParseHuntingSection()
 	// a user to send us a screenshot of the profiling info:
 	RegisterIniKeyBinding(L"Hunting", L"monitor_performance", AnalysePerf, NULL, noRepeat, NULL);
 	RegisterIniKeyBinding(L"Hunting", L"freeze_performance_monitor", FreezePerf, NULL, noRepeat, NULL);
+
+	RegisterIniKeyBinding(L"Hunting", L"cycle_namespace_column", CycleNamespaceColumn, NULL, noRepeat, NULL);
+	RegisterIniKeyBinding(L"Hunting", L"next_namespace", NextNamespace, NULL, noRepeat, NULL);
+	RegisterIniKeyBinding(L"Hunting", L"previous_namespace", PreviousNamespace, NULL, noRepeat, NULL);
+	RegisterIniKeyBinding(L"Hunting", L"next_var", NextVar, NULL, noRepeat, NULL);
+	RegisterIniKeyBinding(L"Hunting", L"previous_var", PreviousVar, NULL, noRepeat, NULL);
+
 	Profiling::interval = (INT64)(GetIniFloat(L"Hunting", L"monitor_performance_interval", 1.0f, NULL) * 1000000);
 
 	// Don't register hunting keys when hard disabled. In this case the

--- a/DirectX11/Hunting.cpp
+++ b/DirectX11/Hunting.cpp
@@ -25,6 +25,8 @@
 //  will lose data, so rather than do anything heroic here, I'm just doing type casts on the strlen function.
 
 Profiling::VariableColumn* selected_column;
+Profiling::ResourcePoolColumn* selected_pool_column;
+Profiling::CustomResourceColumn* selected_resource_column;
 
 DWORD castStrLen(const char* string)
 {
@@ -1302,6 +1304,15 @@ static void AnalysePerf(HackerDevice *device, void *private_data)
 	if (Profiling::mode == Profiling::Mode::COMMAND_LIST_VARIABLES)
 		selected_column = &Profiling::variable_columns[Profiling::active_column];
 
+	if (Profiling::mode == Profiling::Mode::CUSTOM_RESOURCE_POOLS)
+		selected_pool_column = &Profiling::resource_pool_columns[Profiling::active_pool_column];
+
+	if (Profiling::mode == Profiling::Mode::CUSTOM_RESOURCES)
+		selected_resource_column =
+		&Profiling::custom_resource_columns[
+			Profiling::active_custom_resource_column
+		];
+
 	Profiling::text.clear();
 	Profiling::clear();
 }
@@ -1317,79 +1328,491 @@ static void FreezePerf(HackerDevice *device, void *private_data)
 		LogInfoW(L"%s", Profiling::text.c_str());
 }
 
-static void CycleNamespaceColumn(HackerDevice* device, void* private_data)
+static void CycleViewerColumn(
+	HackerDevice* device,
+	void* private_data)
 {
-	if (Profiling::mode == Profiling::Mode::COMMAND_LIST_VARIABLES) {
+	switch (Profiling::mode)
+	{
+	case Profiling::Mode::COMMAND_LIST_VARIABLES:
+	{
 		Profiling::active_column++;
 
-		if (Profiling::active_column > 5)
+		if (Profiling::active_column >=
+			Profiling::variable_columns.size())
+		{
 			Profiling::active_column = 0;
+		}
 
-		selected_column = &Profiling::variable_columns[Profiling::active_column];
+		selected_column =
+			&Profiling::variable_columns[
+				Profiling::active_column
+			];
 
-		Profiling::text.clear();
-		Profiling::clear();
+		break;
 	}
+
+	case Profiling::Mode::CUSTOM_RESOURCES:
+	{
+		Profiling::active_custom_resource_column++;
+
+		if (Profiling::active_custom_resource_column >=
+			Profiling::custom_resource_columns.size())
+		{
+			Profiling::active_custom_resource_column = 0;
+		}
+
+		break;
+	}
+
+	case Profiling::Mode::CUSTOM_RESOURCE_POOLS:
+	{
+		Profiling::active_pool_column++;
+
+		if (Profiling::active_pool_column >=
+			Profiling::resource_pool_columns.size())
+		{
+			Profiling::active_pool_column = 0;
+		}
+
+		break;
+	}
+
+	default:
+		return;
+	}
+
+	Profiling::text.clear();
+	Profiling::clear();
 }
 
-static void NextNamespace(HackerDevice* device, void* private_data)
+static void NextViewerGroup(
+	HackerDevice* device,
+	void* private_data)
 {
-	if (Profiling::mode == Profiling::Mode::COMMAND_LIST_VARIABLES) {
-		selected_column->namespace_index++;
+	switch (Profiling::mode)
+	{
+	case Profiling::Mode::COMMAND_LIST_VARIABLES:
+	{
+		auto& column =
+			Profiling::variable_columns[
+				Profiling::active_column
+			];
 
-		if (selected_column->namespace_index >= namespace_list.size())
-			selected_column->namespace_index = -1;
+		column.namespace_index++;
 
-		Profiling::text.clear();
-		Profiling::clear();
+		if (column.namespace_index >=
+			namespace_list.size())
+		{
+			column.namespace_index = -1;
+		}
+
+		column.scroll_offset = 0;
+
+		break;
 	}
+
+	case Profiling::Mode::CUSTOM_RESOURCES:
+	{
+		auto& column =
+			Profiling::custom_resource_columns[
+				Profiling::active_custom_resource_column
+			];
+
+		column.namespace_index++;
+
+		if (column.namespace_index >=
+			custom_resource_namespace_list.size())
+		{
+			column.namespace_index = -1;
+		}
+
+		column.resource_index = 0;
+		column.scroll_offset = 0;
+
+		break;
+	}
+
+	case Profiling::Mode::CUSTOM_RESOURCE_POOLS:
+	{
+		auto& column =
+			Profiling::resource_pool_columns[
+				Profiling::active_pool_column
+			];
+
+		column.pool_index++;
+
+		if (column.pool_index >=
+			resource_pool_list.size())
+		{
+			column.pool_index = -1;
+		}
+
+		column.scroll_offset = 0;
+
+		break;
+	}
+
+	default:
+		return;
+	}
+
+	Profiling::text.clear();
+	Profiling::clear();
 }
 
-static void PreviousNamespace(HackerDevice* device, void* private_data)
+static void PreviousViewerGroup(
+	HackerDevice* device,
+	void* private_data)
 {
-	if (Profiling::mode == Profiling::Mode::COMMAND_LIST_VARIABLES) {
-		selected_column->namespace_index--;
+	switch (Profiling::mode)
+	{
+	case Profiling::Mode::COMMAND_LIST_VARIABLES:
+	{
+		auto& column =
+			Profiling::variable_columns[
+				Profiling::active_column
+			];
 
-		if (selected_column->namespace_index < -1)
-			selected_column->namespace_index = namespace_list.size()-1;
+		column.namespace_index--;
 
-		Profiling::text.clear();
-		Profiling::clear();
+		if (column.namespace_index < -1)
+		{
+			column.namespace_index =
+				(int)namespace_list.size() - 1;
+		}
+
+		column.scroll_offset = 0;
+
+		break;
 	}
+
+	case Profiling::Mode::CUSTOM_RESOURCES:
+	{
+		auto& column =
+			Profiling::custom_resource_columns[
+				Profiling::active_custom_resource_column
+			];
+
+		column.namespace_index--;
+
+		if (column.namespace_index < -1)
+		{
+			column.namespace_index =
+				(int)custom_resource_namespace_list.size() - 1;
+		}
+
+		column.resource_index = 0;
+		column.scroll_offset = 0;
+
+		break;
+	}
+
+	case Profiling::Mode::CUSTOM_RESOURCE_POOLS:
+	{
+		auto& column =
+			Profiling::resource_pool_columns[
+				Profiling::active_pool_column
+			];
+
+		column.pool_index--;
+
+		if (column.pool_index < -1)
+		{
+			column.pool_index =
+				(int)resource_pool_list.size() - 1;
+		}
+
+		column.scroll_offset = 0;
+
+		break;
+	}
+
+	default:
+		return;
+	}
+
+	Profiling::text.clear();
+	Profiling::clear();
 }
 
-static void NextVar(HackerDevice* device, void* private_data)
+static void NextGroupElement(
+	HackerDevice* device,
+	void* private_data)
 {
-	if (Profiling::mode == Profiling::Mode::COMMAND_LIST_VARIABLES) {
+	switch (Profiling::mode)
+	{
+	case Profiling::Mode::COMMAND_LIST_VARIABLES:
+	{
+		auto& column =
+			Profiling::variable_columns[
+				Profiling::active_column
+			];
 
-		if (variable_groups[namespace_list[selected_column->namespace_index]].size() < Profiling::visible_rows || selected_column->namespace_index == -1)
+		if (column.namespace_index == -1)
 			return;
 
-		selected_column->scroll_offset++;
+		auto& variables =
+			variable_groups[
+				namespace_list[
+					column.namespace_index
+				]
+			];
 
-		if (selected_column->scroll_offset > (variable_groups[namespace_list[selected_column->namespace_index]].size() - Profiling::visible_rows))
-			selected_column->scroll_offset = 0;
-
-		Profiling::text.clear();
-		Profiling::clear();
-	}
-}
-
-static void PreviousVar(HackerDevice* device, void* private_data)
-{
-	if (Profiling::mode == Profiling::Mode::COMMAND_LIST_VARIABLES) {
-
-		if (variable_groups[namespace_list[selected_column->namespace_index]].size() < Profiling::visible_rows || selected_column->namespace_index == -1)
+		if (variables.size() <= Profiling::visible_rows)
 			return;
 
-		selected_column->scroll_offset--;
+		int max_scroll =
+			(int)variables.size() -
+			Profiling::visible_rows;
 
-		if (selected_column->scroll_offset < 0)
-			selected_column->scroll_offset = variable_groups[namespace_list[selected_column->namespace_index]].size() - Profiling::visible_rows;
+		column.scroll_offset++;
 
-		Profiling::text.clear();
-		Profiling::clear();
+		if (column.scroll_offset > max_scroll)
+			column.scroll_offset = 0;
+
+		break;
 	}
+
+
+	case Profiling::Mode::CUSTOM_RESOURCES:
+	{
+		auto& column =
+			Profiling::custom_resource_columns[
+				Profiling::active_custom_resource_column
+			];
+
+		if (column.namespace_index == -1)
+			return;
+
+		auto& resources =
+			custom_resource_groups[
+				custom_resource_namespace_list[
+					column.namespace_index
+				]
+			];
+
+		if (resources.empty())
+			return;
+
+		/*
+		 * Selected Resource
+		 */
+		column.resource_index++;
+
+		if (column.resource_index >=
+			resources.size())
+		{
+			column.resource_index = 0;
+		}
+
+
+		/*
+		 * Keep selected Resource visible.
+		 */
+		if (column.resource_index >=
+			column.scroll_offset +
+			Profiling::custom_resource_visible_rows)
+		{
+			column.scroll_offset =
+				column.resource_index -
+				Profiling::custom_resource_visible_rows +
+				1;
+		}
+
+		if (column.resource_index <
+			column.scroll_offset)
+		{
+			column.scroll_offset =
+				column.resource_index;
+		}
+
+		break;
+	}
+
+
+	case Profiling::Mode::CUSTOM_RESOURCE_POOLS:
+	{
+		auto& column =
+			Profiling::resource_pool_columns[
+				Profiling::active_pool_column
+			];
+
+		if (column.pool_index == -1)
+			return;
+
+		auto& pool =
+			customResourcePools[
+				resource_pool_list[
+					column.pool_index
+				]
+			];
+
+		if (pool.GetElements().size() <=
+			Profiling::visible_rows)
+		{
+			return;
+		}
+
+		int max_scroll =
+			(int)pool.GetElements().size() -
+			Profiling::visible_rows;
+
+		column.scroll_offset++;
+
+		if (column.scroll_offset > max_scroll)
+			column.scroll_offset = 0;
+
+		break;
+	}
+
+
+	default:
+		return;
+	}
+
+	Profiling::text.clear();
+	Profiling::clear();
+}
+
+static void PreviousGroupElement(
+	HackerDevice* device,
+	void* private_data)
+{
+	switch (Profiling::mode)
+	{
+	case Profiling::Mode::COMMAND_LIST_VARIABLES:
+	{
+		auto& column =
+			Profiling::variable_columns[
+				Profiling::active_column
+			];
+
+		if (column.namespace_index == -1)
+			return;
+
+		auto& variables =
+			variable_groups[
+				namespace_list[
+					column.namespace_index
+				]
+			];
+
+		if (variables.size() <= Profiling::visible_rows)
+			return;
+
+		int max_scroll =
+			(int)variables.size() -
+			Profiling::visible_rows;
+
+		column.scroll_offset--;
+
+		if (column.scroll_offset < 0)
+			column.scroll_offset = max_scroll;
+
+		break;
+	}
+
+
+	case Profiling::Mode::CUSTOM_RESOURCES:
+	{
+		auto& column =
+			Profiling::custom_resource_columns[
+				Profiling::active_custom_resource_column
+			];
+
+		if (column.namespace_index == -1)
+			return;
+
+		auto& resources =
+			custom_resource_groups[
+				custom_resource_namespace_list[
+					column.namespace_index
+				]
+			];
+
+		if (resources.empty())
+			return;
+
+
+		/*
+		 * Selected Resource
+		 */
+		column.resource_index--;
+
+		if (column.resource_index < 0)
+		{
+			column.resource_index =
+				(int)resources.size() - 1;
+		}
+
+
+		/*
+		 * Keep selected Resource visible.
+		 */
+		if (column.resource_index <
+			column.scroll_offset)
+		{
+			column.scroll_offset =
+				column.resource_index;
+		}
+
+		if (column.resource_index >=
+			column.scroll_offset +
+			Profiling::custom_resource_visible_rows)
+		{
+			column.scroll_offset =
+				column.resource_index -
+				Profiling::custom_resource_visible_rows +
+				1;
+		}
+
+		break;
+	}
+
+
+	case Profiling::Mode::CUSTOM_RESOURCE_POOLS:
+	{
+		auto& column =
+			Profiling::resource_pool_columns[
+				Profiling::active_pool_column
+			];
+
+		if (column.pool_index == -1)
+			return;
+
+		auto& pool =
+			customResourcePools[
+				resource_pool_list[
+					column.pool_index
+				]
+			];
+
+		if (pool.GetElements().size() <=
+			Profiling::visible_rows)
+		{
+			return;
+		}
+
+		int max_scroll =
+			(int)pool.GetElements().size() -
+			Profiling::visible_rows;
+
+		column.scroll_offset--;
+
+		if (column.scroll_offset < 0)
+			column.scroll_offset = max_scroll;
+
+		break;
+	}
+
+
+	default:
+		return;
+	}
+
+	Profiling::text.clear();
+	Profiling::clear();
 }
 
 static void DisableDeferred(HackerDevice *device, void *private_data)
@@ -2058,11 +2481,13 @@ void ParseHuntingSection()
 	RegisterIniKeyBinding(L"Hunting", L"monitor_performance", AnalysePerf, NULL, noRepeat, NULL);
 	RegisterIniKeyBinding(L"Hunting", L"freeze_performance_monitor", FreezePerf, NULL, noRepeat, NULL);
 
-	RegisterIniKeyBinding(L"Hunting", L"cycle_namespace_column", CycleNamespaceColumn, NULL, noRepeat, NULL);
-	RegisterIniKeyBinding(L"Hunting", L"next_namespace", NextNamespace, NULL, noRepeat, NULL);
-	RegisterIniKeyBinding(L"Hunting", L"previous_namespace", PreviousNamespace, NULL, noRepeat, NULL);
-	RegisterIniKeyBinding(L"Hunting", L"next_var", NextVar, NULL, noRepeat, NULL);
-	RegisterIniKeyBinding(L"Hunting", L"previous_var", PreviousVar, NULL, noRepeat, NULL);
+	// Values Viewer
+	RegisterIniKeyBinding(L"Hunting", L"cycle_viewer_column", CycleViewerColumn, NULL, noRepeat, NULL);
+	RegisterIniKeyBinding(L"Hunting", L"next_viewer_group", NextViewerGroup, NULL, noRepeat, NULL);
+	RegisterIniKeyBinding(L"Hunting", L"previous_viewer_group", PreviousViewerGroup, NULL, noRepeat, NULL);
+	RegisterIniKeyBinding(L"Hunting", L"next_group_element", NextGroupElement, NULL, noRepeat, NULL);
+	RegisterIniKeyBinding(L"Hunting", L"previous_group_element", PreviousGroupElement, NULL, noRepeat, NULL);
+
 
 	Profiling::interval = (INT64)(GetIniFloat(L"Hunting", L"monitor_performance_interval", 1.0f, NULL) * 1000000);
 

--- a/DirectX11/IniHandler.cpp
+++ b/DirectX11/IniHandler.cpp
@@ -4800,5 +4800,42 @@ void ReloadConfig(HackerDevice *device)
 	auto stop = std::chrono::high_resolution_clock::now();
 	std::chrono::duration<float> duration = stop - start;
 
+	variableList.clear();
+	variable_groups.clear();
+	namespace_list.clear();
+
+	for (auto& var : command_list_globals)
+	{
+		VariableEntry entry;
+
+		const std::wstring& key = var.first;
+
+		size_t lastSlash = key.find_last_of(L'\\');
+
+		std::wstring ns = key.substr(2, lastSlash - 2);
+
+		if (ns.compare(0, 5, L"mods\\") == 0)
+		{
+			ns.erase(0, 5);
+		}
+
+		entry.var_namespace = ns;
+
+		entry.name = key.substr(lastSlash + 1);
+		entry.variable = &var.second;
+
+		variableList.push_back(entry);
+	}
+
+	for (auto& var : variableList)
+	{
+		variable_groups[var.var_namespace].push_back(&var);
+	}
+
+	for (auto& group : variable_groups)
+	{
+		namespace_list.push_back(group.first);
+	}
+
 	LogOverlayW(LOG_INFO, L"> Reloaded config in %.3fs\n", duration.count());
 }

--- a/DirectX11/IniHandler.cpp
+++ b/DirectX11/IniHandler.cpp
@@ -4509,7 +4509,7 @@ void LoadConfigFile()
 	// TODO: Enable this by default if wider testing goes well:
 	G->check_foreground_window = GetIniBool(L"System", L"check_foreground_window", false, NULL);
 
-	// Allows to change interval between persistent vars autosaving to d3dx_user.ini (any negative number to disables it)
+	// Allows to change interval between persistent vars autosaving to d3dx_user.ini (any negative number to disable it)
 	G->gSettingsAutoSaveInterval = GetIniInt(L"System", L"settings_auto_save_interval", 60, NULL);
 	if (G->gSettingsAutoSaveInterval < 0) {
 		G->gSettingsAutoSaveInterval = 2147483647;
@@ -4845,13 +4845,52 @@ void SavePersistentSettings()
 
 	if (!G->user_config_dirty)
 		return;
-	G->user_config_dirty = 0;
 
 	setlocale(LC_CTYPE, "en_US.UTF-8");
 
 	// TODO: Ability to update existing file rather than overwriting:
 	//wfopen_ensuring_access(&f, G->user_config.c_str(), L"r+");
 	//if (!f)
+
+	std::unordered_map<std::wstring, float> saved_variables;
+
+	if (!G->gReloadConfigPending) {
+
+		// Read Existing Variables from File.
+		if (_wfopen_s(&f, G->user_config.c_str(), L"r") == 0 && f) {
+			wchar_t line[1024];
+
+			while (fgetws(line, _countof(line), f)) {
+				if (line[0] != L'$')
+					continue;
+
+				wchar_t* equals = wcschr(line, L'=');
+				if (!equals)
+					continue;
+
+				*equals = L'\0';
+
+				wchar_t* name_end = equals - 1;
+
+				while (name_end >= line &&
+					(*name_end == L' ' || *name_end == L'\t'))
+				{
+					name_end--;
+				}
+
+				*(name_end + 1) = L'\0';
+
+				float value;
+				if (swscanf_s(equals + 1, L"%f", &value) != 1)
+					continue;
+
+				saved_variables[line] = value;
+			}
+
+			fclose(f);
+		}
+	}
+
 	wfopen_ensuring_access(&f, G->user_config.c_str(), L"w");
 	if (!f) {
 		LogInfo("Unable to save settings in %S\n", G->user_config.c_str());
@@ -4869,8 +4908,25 @@ void SavePersistentSettings()
 	      ";\n"
 	      "[Constants]\n", f);
 
-	for (auto global : persistent_variables)
-		fprintf_s(f, "%ls = %.9g\n", global->name.c_str(), global->fval);
+
+	if (!G->gReloadConfigPending) {
+
+		for (auto global : persistent_variables) {
+			fprintf_s(f, "%ls = %.9g\n", global->name.c_str(), global->fval);
+			saved_variables.erase(global->name);
+		}
+
+		for (auto& entry : saved_variables)
+			fprintf_s(f, "%ls = %.9g\n", entry.first.c_str(), entry.second);
+	}
+	
+	else {
+		for (auto global : persistent_variables)
+			fprintf_s(f, "%ls = %.9g\n", global->name.c_str(), global->fval);
+
+		G->user_config_dirty = 0;
+	}
+
 
 	fclose(f);
 

--- a/DirectX11/IniHandler.cpp
+++ b/DirectX11/IniHandler.cpp
@@ -5041,6 +5041,10 @@ void ReloadConfig(HackerDevice *device)
 	auto stop = std::chrono::high_resolution_clock::now();
 	std::chrono::duration<float> duration = stop - start;
 
+	// Values Viewer
+
+	// Variables
+
 	variableList.clear();
 	variable_groups.clear();
 	namespace_list.clear();
@@ -5076,6 +5080,66 @@ void ReloadConfig(HackerDevice *device)
 	for (auto& group : variable_groups)
 	{
 		namespace_list.push_back(group.first);
+	}
+
+	// Custom Resources
+
+	customResourceList.clear();
+	custom_resource_groups.clear();
+	custom_resource_namespace_list.clear();
+
+	for (auto& resource : customResources)
+	{
+		CustomResourceEntry entry;
+
+		const std::wstring& key = resource.first;
+
+		size_t lastSlash = key.find_last_of(L'\\');
+
+		if (lastSlash == std::wstring::npos)
+		{
+			entry.resource_namespace = L"";
+			entry.name = key;
+		}
+		else
+		{
+			// CustomResource names use the same namespaced key format
+			// as command list globals: the first two characters are
+			// the resource namespace prefix.
+			std::wstring ns = key.substr(2, lastSlash - 2);
+
+			if (ns.compare(0, 5, L"mods\\") == 0)
+				ns.erase(0, 5);
+
+			entry.resource_namespace = ns;
+			entry.name = key.substr(lastSlash + 1);
+		}
+
+		entry.resource = &resource.second;
+
+		customResourceList.push_back(entry);
+	}
+
+	for (auto& resource : customResourceList)
+	{
+		custom_resource_groups[
+			resource.resource_namespace
+		].push_back(&resource);
+	}
+
+	for (auto& group : custom_resource_groups)
+	{
+		custom_resource_namespace_list.push_back(group.first);
+	}
+
+
+	// Pools
+
+	resource_pool_list.clear();
+
+	for (auto& pool : customResourcePools)
+	{
+		resource_pool_list.push_back(pool.first);
 	}
 
 	LogOverlayW(LOG_INFO, L"> Reloaded config in %.3fs\n", duration.count());

--- a/DirectX11/profiling.cpp
+++ b/DirectX11/profiling.cpp
@@ -47,6 +47,12 @@ namespace Profiling {
 	unsigned skipped_draw_calls;
 	unsigned max_executions_per_frame_exceeded;
 	unsigned iniparams_updates;
+
+	std::vector<VariableColumn> variable_columns(6);
+	int active_column = 0;
+
+	const int column_width = 40;
+	const int visible_rows = 61;
 }
 
 static LARGE_INTEGER profiling_start_time;
@@ -118,6 +124,181 @@ static void update_txt_cto_warning()
 {
 	Profiling::text += L" (post [TextureOverride] commands):\n" + Profiling::cto_warning;
 }
+
+static std::wstring TrimNamespace(const std::wstring& name, int max_length)
+{
+	if (name.size() <= max_length)
+		return name;
+
+
+	std::wstring result = name;
+
+
+	while (result.size() > max_length)
+	{
+		size_t pos = result.find(L'\\');
+
+		if (pos == std::wstring::npos)
+			break;
+
+		result.erase(0, pos + 1);
+	}
+
+	if (result.size() > max_length)
+	{
+		result = result.substr(0, max_length - 3);
+		result += L"...";
+	}
+
+
+	return result;
+}
+
+static void AddColumn(std::wstring& output, std::wstring text, int width)
+{
+	output += text;
+
+	while (text.size() < width)
+	{
+		output += L" ";
+		text += L" ";
+	}
+}
+
+
+static std::wstring GetColumnHeader(int index)
+{
+	auto& column = Profiling::variable_columns[index];
+
+	std::wstring name = L"Select";
+
+	if (column.namespace_index >= 0 &&
+		column.namespace_index < namespace_list.size())
+	{
+		name = namespace_list[column.namespace_index];
+	}
+
+	if (index == Profiling::active_column)
+	{
+		return L"<" + name + L">";
+	}
+
+	return name;
+}
+
+
+static void DrawVariables()
+{
+	Profiling::text += L"\n\n";
+
+	// ============================
+	// Namespace Counters
+	// ============================
+
+	for (int c = 0; c < Profiling::variable_columns.size(); c++)
+	{
+		std::wstring counter;
+
+		if (c == Profiling::active_column)
+		{
+			auto& column = Profiling::variable_columns[c];
+
+			if (column.namespace_index >= 0)
+			{
+				counter =
+					std::to_wstring(column.namespace_index + 1) +
+					L"/" +
+					std::to_wstring(namespace_list.size());
+			}
+			else
+			{
+				counter = L"0/" + std::to_wstring(namespace_list.size());
+			}
+		}
+
+		AddColumn(
+			Profiling::text,
+			counter,
+			Profiling::column_width
+		);
+	}
+
+	Profiling::text += L"\n";
+
+
+	// ============================
+	// Namespace Headers
+	// ============================
+
+	for (int c = 0; c < Profiling::variable_columns.size(); c++)
+	{
+		std::wstring header =
+			TrimNamespace(
+				GetColumnHeader(c),
+				Profiling::column_width
+			);
+
+		AddColumn(
+			Profiling::text,
+			header,
+			Profiling::column_width
+		);
+	}
+
+	Profiling::text += L"\n\n";
+
+
+	// ============================
+	// Variables
+	// ============================
+
+	for (int row = 0; row < Profiling::visible_rows; row++)
+	{
+		for (int c = 0; c < Profiling::variable_columns.size(); c++)
+		{
+			auto& column = Profiling::variable_columns[c];
+
+			std::wstring text;
+
+
+			if (column.namespace_index >= 0 &&
+				column.namespace_index < namespace_list.size())
+			{
+				auto& vars =
+					variable_groups[
+						namespace_list[column.namespace_index]
+					];
+
+
+				int index = row + column.scroll_offset;
+
+
+				if (index < vars.size())
+				{
+					auto* var = vars[index];
+
+
+					text += L"$";
+					text += var->name;
+					text += L" = ";
+					text += std::to_wstring(
+						var->variable->fval
+					);
+				}
+			}
+
+
+			AddColumn(
+				Profiling::text,
+				text,
+				Profiling::column_width
+			);
+		}
+
+		Profiling::text += L"\n";
+	}
+}
+
 
 static void update_txt_summary(LARGE_INTEGER collection_duration, LARGE_INTEGER freq, unsigned frames)
 {
@@ -409,7 +590,7 @@ void Profiling::update_txt()
 		return;
 
 	collection_duration.QuadPart = (end_time.QuadPart - profiling_start_time.QuadPart) * 1000000 / freq.QuadPart;
-	if (collection_duration.QuadPart < interval && !Profiling::text.empty())
+	if (collection_duration.QuadPart < ((Profiling::mode == Profiling::Mode::COMMAND_LIST_VARIABLES) ? 0.1 : interval) && !Profiling::text.empty())
 		return;
 
 	if (frames && collection_duration.QuadPart) {
@@ -429,6 +610,9 @@ void Profiling::update_txt()
 				break;
 			case Profiling::Mode::CTO_WARNING:
 				update_txt_cto_warning();
+				break;
+			case Profiling::Mode::COMMAND_LIST_VARIABLES:
+				DrawVariables();
 				break;
 		}
 	}

--- a/DirectX11/profiling.cpp
+++ b/DirectX11/profiling.cpp
@@ -48,11 +48,28 @@ namespace Profiling {
 	unsigned max_executions_per_frame_exceeded;
 	unsigned iniparams_updates;
 
-	std::vector<VariableColumn> variable_columns(6);
-	int active_column = 0;
+	// Values Viewer
 
 	const int column_width = 40;
 	const int visible_rows = 61;
+
+	// Variables
+
+	std::vector<VariableColumn> variable_columns(6);
+	int active_column = 0;
+
+	// Pools
+
+	std::vector<ResourcePoolColumn> resource_pool_columns(6);
+	int active_pool_column = 0;
+
+	// Custom Resources
+
+	std::vector<CustomResourceColumn> custom_resource_columns(6);
+	int active_custom_resource_column = 0;
+
+	const int custom_resource_metadata_rows = 16;
+	const int custom_resource_visible_rows = visible_rows - custom_resource_metadata_rows - 1;
 }
 
 static LARGE_INTEGER profiling_start_time;
@@ -124,6 +141,8 @@ static void update_txt_cto_warning()
 {
 	Profiling::text += L" (post [TextureOverride] commands):\n" + Profiling::cto_warning;
 }
+
+// Values Viewer
 
 static std::wstring TrimNamespace(const std::wstring& name, int max_length)
 {
@@ -291,6 +310,1026 @@ static void DrawVariables()
 			AddColumn(
 				Profiling::text,
 				text,
+				Profiling::column_width
+			);
+		}
+
+		Profiling::text += L"\n";
+	}
+}
+
+// ============================
+// POOLS
+// ============================
+
+
+
+static std::wstring GetResourcePoolHeader(int index)
+{
+	auto& column = Profiling::resource_pool_columns[index];
+
+	std::wstring name = L"Select";
+
+	if (column.pool_index >= 0 &&
+		column.pool_index < resource_pool_list.size())
+	{
+		name = resource_pool_list[column.pool_index];
+	}
+
+	if (index == Profiling::active_pool_column)
+	{
+		return L"<" + name + L">";
+	}
+
+	return name;
+}
+
+static std::wstring GetPoolElementType(const PoolElement& element)
+{
+	switch (element.type)
+	{
+	case PoolElement::Type::Resource:
+		return L"Resource";
+
+	case PoolElement::Type::Variable:
+		return L"Variable";
+
+	case PoolElement::Type::Mixed:
+		return L"Mixed";
+
+	default:
+		return L"None";
+	}
+}
+
+static float GetResourceId(CustomResource* resource)
+{
+	if (!resource || resource->is_null || !resource->resource)
+		return 0.0f;
+
+	uint64_t hash = HashPointer(resource->resource);
+
+	return EncodeFloat30((uint32_t)hash);
+}
+
+static void DrawResourcePools()
+{
+	Profiling::text += L"\n\n";
+
+
+	// ============================
+	// Pool Counters
+	// ============================
+
+	for (int c = 0; c < Profiling::resource_pool_columns.size(); c++)
+	{
+		std::wstring counter;
+
+		if (c == Profiling::active_pool_column)
+		{
+			auto& column = Profiling::resource_pool_columns[c];
+
+			if (column.pool_index >= 0)
+			{
+				counter =
+					std::to_wstring(column.pool_index + 1) +
+					L"/" +
+					std::to_wstring(resource_pool_list.size());
+			}
+			else
+			{
+				counter =
+					L"0/" +
+					std::to_wstring(resource_pool_list.size());
+			}
+		}
+
+		AddColumn(
+			Profiling::text,
+			counter,
+			Profiling::column_width
+		);
+	}
+
+	Profiling::text += L"\n";
+
+
+	// ============================
+	// Pool Headers
+	// ============================
+
+	for (int c = 0; c < Profiling::resource_pool_columns.size(); c++)
+	{
+		std::wstring header =
+			TrimNamespace(
+				GetResourcePoolHeader(c),
+				Profiling::column_width
+			);
+
+		AddColumn(
+			Profiling::text,
+			header,
+			Profiling::column_width
+		);
+	}
+
+	Profiling::text += L"\n\n";
+
+
+	// ============================
+	// Pool Elements
+	// ============================
+
+	for (int row = 0; row < Profiling::visible_rows; row++)
+	{
+		for (int c = 0; c < Profiling::resource_pool_columns.size(); c++)
+		{
+			auto& column = Profiling::resource_pool_columns[c];
+
+			std::wstring text;
+
+
+			if (column.pool_index >= 0 &&
+				column.pool_index < resource_pool_list.size())
+			{
+				auto& pool =
+					customResourcePools[
+						resource_pool_list[column.pool_index]
+					];
+
+
+				int index = row + column.scroll_offset;
+
+
+				if (index < pool.GetElements().size())
+				{
+					auto& element = pool.GetElements()[index];
+
+					text += std::to_wstring(index);
+					text += L" ";
+
+					text += GetPoolElementType(element);
+
+
+					if (element.resource)
+					{
+						text += L" ";
+
+						float resource_id = GetResourceId(element.resource);
+
+						wchar_t buffer[64];
+						swprintf_s(
+							buffer,
+							_countof(buffer),
+							L"%.*g",
+							9,
+							resource_id
+						);
+
+						text += (resource_id == 0.0 ? L"Null" : buffer);
+					}
+
+					if (element.variable)
+					{
+						text += L" ";
+						text += std::to_wstring(element.variable->fval);
+					}
+				}
+			}
+
+
+			AddColumn(
+				Profiling::text,
+				text,
+				Profiling::column_width
+			);
+		}
+
+		Profiling::text += L"\n";
+	}
+}
+
+// ============================
+// RESOURCES
+// ============================
+
+static std::wstring FormatToWString(DXGI_FORMAT format)
+{
+	if (format == DXGI_FORMAT_UNKNOWN ||
+		format == (DXGI_FORMAT)-1)
+	{
+		return L"Unknown";
+	}
+
+	const char* str = TexFormatStr(format);
+
+	if (!str)
+		return L"Unknown";
+
+	return std::wstring(str, str + strlen(str));
+}
+
+
+static std::wstring CustomResourceTypeToWString(
+	CustomResourceType type)
+{
+	switch (type)
+	{
+	case CustomResourceType::BUFFER:
+		return L"Buffer";
+
+	case CustomResourceType::STRUCTURED_BUFFER:
+		return L"StructuredBuffer";
+
+	case CustomResourceType::RAW_BUFFER:
+		return L"RawBuffer";
+
+	case CustomResourceType::TEXTURE1D:
+		return L"Texture1D";
+
+	case CustomResourceType::TEXTURE2D:
+		return L"Texture2D";
+
+	case CustomResourceType::TEXTURE3D:
+		return L"Texture3D";
+
+	case CustomResourceType::CUBE:
+		return L"Cube";
+
+	case CustomResourceType::INVALID:
+	default:
+		return L"Unknown";
+	}
+}
+
+
+static std::wstring GetActualResourceType(
+	ID3D11Resource* resource)
+{
+	if (!resource)
+		return L"Unknown";
+
+	D3D11_RESOURCE_DIMENSION dimension =
+		D3D11_RESOURCE_DIMENSION_UNKNOWN;
+
+	resource->GetType(&dimension);
+
+	switch (dimension)
+	{
+	case D3D11_RESOURCE_DIMENSION_BUFFER:
+	{
+		D3D11_BUFFER_DESC desc;
+		static_cast<ID3D11Buffer*>(resource)->GetDesc(&desc);
+
+		if (desc.StructureByteStride != 0)
+			return L"StructuredBuffer";
+
+		if (desc.MiscFlags &
+			D3D11_RESOURCE_MISC_BUFFER_ALLOW_RAW_VIEWS)
+		{
+			return L"RawBuffer";
+		}
+
+		return L"Buffer";
+	}
+
+	case D3D11_RESOURCE_DIMENSION_TEXTURE1D:
+		return L"Texture1D";
+
+	case D3D11_RESOURCE_DIMENSION_TEXTURE2D:
+		return L"Texture2D";
+
+	case D3D11_RESOURCE_DIMENSION_TEXTURE3D:
+		return L"Texture3D";
+
+	default:
+		return L"Unknown";
+	}
+}
+
+
+static std::wstring TrimText(
+	const std::wstring& text,
+	int max_length)
+{
+	if (max_length <= 0)
+		return L"";
+
+	if ((int)text.size() <= max_length)
+		return text;
+
+	if (max_length <= 3)
+		return text.substr(0, max_length);
+
+	return text.substr(0, max_length - 3) + L"...";
+}
+
+
+// ---------------------------------------------------------------------------
+// Returns everything after "mods\"
+//
+// source\mods\iris\kamisatoayaka.ini
+//            ^---------------------
+//
+// -> iris\kamisatoayaka.ini
+//
+// Also works for absolute paths containing "\mods\".
+// ---------------------------------------------------------------------------
+
+static std::wstring GetAfterMods(
+	const std::wstring& path)
+{
+	static const std::wstring marker = L"mods\\";
+
+	std::wstring lower = path;
+
+	std::transform(
+		lower.begin(),
+		lower.end(),
+		lower.begin(),
+		::towlower
+	);
+
+	size_t pos = lower.find(marker);
+
+	if (pos == std::wstring::npos)
+		return path;
+
+	return path.substr(pos + marker.size());
+}
+
+
+// ---------------------------------------------------------------------------
+// Last path component.
+//
+// iris\kamisatoayaka.ini
+// -> kamisatoayaka.ini
+// ---------------------------------------------------------------------------
+
+static std::wstring GetLastPathComponent(
+	const std::wstring& path)
+{
+	size_t pos = path.find_last_of(L"\\/");
+
+	if (pos == std::wstring::npos)
+		return path;
+
+	return path.substr(pos + 1);
+}
+
+
+static std::wstring GetCustomResourceColumnHeader(int index)
+{
+	auto& column =
+		Profiling::custom_resource_columns[index];
+
+	if (
+		column.namespace_index < 0 ||
+		column.namespace_index >=
+		(int)custom_resource_namespace_list.size()
+		)
+	{
+		return L"Select";
+	}
+
+	std::wstring name =
+		custom_resource_namespace_list[
+			column.namespace_index
+		];
+
+	std::wstring lower = name;
+
+	std::transform(
+		lower.begin(),
+		lower.end(),
+		lower.begin(),
+		::towlower
+	);
+
+	const std::wstring mods_marker = L"mods\\";
+	const std::wstring source_prefix = L"source\\";
+
+	size_t mods_pos = lower.find(mods_marker);
+
+	if (mods_pos != std::wstring::npos)
+	{
+		name.erase(
+			0,
+			mods_pos + mods_marker.size()
+		);
+	}
+	else if (
+		lower.compare(
+			0,
+			source_prefix.size(),
+			source_prefix
+		) == 0
+		)
+	{
+		name.erase(
+			0,
+			source_prefix.size()
+		);
+	}
+
+	if (index == Profiling::active_custom_resource_column)
+		return L"<" + name + L">";
+
+	return name;
+}
+
+
+static void GetResourceMetadata(
+	const CustomResource* resource,
+	std::wstring lines[16])
+{
+	for (int i = 0; i < 16; i++)
+		lines[i].clear();
+
+	if (!resource)
+	{
+		lines[0] = L"Name: <none>";
+		return;
+	}
+
+
+	// ========================================================================
+	// Common information
+	// ========================================================================
+
+	lines[0] =
+		L"Name: " +
+		GetLastPathComponent(resource->name);
+
+	lines[1] =
+		L"FileName: " +
+		GetAfterMods(resource->filename);
+
+
+	// ========================================================================
+	// Actual D3D11 Resource
+	// ========================================================================
+
+	if (resource->resource)
+	{
+		D3D11_RESOURCE_DIMENSION dimension =
+			D3D11_RESOURCE_DIMENSION_UNKNOWN;
+
+		resource->resource->GetType(&dimension);
+
+		lines[2] =
+			L"Type: " +
+			GetActualResourceType(resource->resource);
+
+
+		switch (dimension)
+		{
+		case D3D11_RESOURCE_DIMENSION_BUFFER:
+		{
+			D3D11_BUFFER_DESC desc;
+			static_cast<ID3D11Buffer*>(
+				resource->resource
+				)->GetDesc(&desc);
+
+			lines[3] =
+				L"Format: Unknown";
+
+			lines[4] =
+				L"ByteWidth: " +
+				std::to_wstring(desc.ByteWidth);
+
+			lines[5] =
+				L"Stride: " +
+				std::to_wstring(
+					resource->stride
+				);
+
+			lines[6] =
+				L"Bind: " +
+				std::to_wstring(
+					static_cast<unsigned>(
+						resource->bind_flags
+						)
+				);
+
+			lines[7] =
+				L"Misc: " +
+				std::to_wstring(
+					static_cast<unsigned>(
+						resource->misc_flags
+						)
+				);
+
+			lines[8] =
+				L"SourceStride: " +
+				std::to_wstring(
+					resource->source_stride
+				);
+
+			break;
+		}
+
+
+		case D3D11_RESOURCE_DIMENSION_TEXTURE1D:
+		{
+			D3D11_TEXTURE1D_DESC desc;
+			static_cast<ID3D11Texture1D*>(
+				resource->resource
+				)->GetDesc(&desc);
+
+			lines[3] =
+				L"Format: " +
+				FormatToWString(desc.Format);
+
+			lines[4] =
+				L"Size: " +
+				std::to_wstring(desc.Width);
+
+			lines[5] =
+				L"Mips: " +
+				std::to_wstring(desc.MipLevels);
+
+			lines[6] =
+				L"Array: " +
+				std::to_wstring(desc.ArraySize);
+
+			lines[7] =
+				L"Bind: " +
+				std::to_wstring(
+					static_cast<unsigned>(
+						resource->bind_flags
+						)
+				);
+
+			lines[8] =
+				L"Misc: " +
+				std::to_wstring(
+					static_cast<unsigned>(
+						resource->misc_flags
+						)
+				);
+
+			lines[9] =
+				L"SourceStride: " +
+				std::to_wstring(
+					resource->source_stride
+				);
+
+			break;
+		}
+
+
+		case D3D11_RESOURCE_DIMENSION_TEXTURE2D:
+		{
+			D3D11_TEXTURE2D_DESC desc;
+			static_cast<ID3D11Texture2D*>(
+				resource->resource
+				)->GetDesc(&desc);
+
+			lines[3] =
+				L"Format: " +
+				FormatToWString(desc.Format);
+
+			lines[4] =
+				L"Size: " +
+				std::to_wstring(desc.Width) +
+				L"x" +
+				std::to_wstring(desc.Height);
+
+			lines[5] =
+				L"Mips: " +
+				std::to_wstring(desc.MipLevels);
+
+			lines[6] =
+				L"Array: " +
+				std::to_wstring(desc.ArraySize);
+
+			lines[7] =
+				L"MSAA: " +
+				std::to_wstring(
+					desc.SampleDesc.Count
+				) +
+				L"/" +
+				std::to_wstring(
+					desc.SampleDesc.Quality
+				);
+
+			lines[8] =
+				L"Bind: " +
+				std::to_wstring(
+					static_cast<unsigned>(
+						resource->bind_flags
+						)
+				);
+
+			lines[9] =
+				L"Misc: " +
+				std::to_wstring(
+					static_cast<unsigned>(
+						resource->misc_flags
+						)
+				);
+
+			lines[10] =
+				L"SourceStride: " +
+				std::to_wstring(
+					resource->source_stride
+				);
+
+			break;
+		}
+
+
+		case D3D11_RESOURCE_DIMENSION_TEXTURE3D:
+		{
+			D3D11_TEXTURE3D_DESC desc;
+			static_cast<ID3D11Texture3D*>(
+				resource->resource
+				)->GetDesc(&desc);
+
+			lines[3] =
+				L"Format: " +
+				FormatToWString(desc.Format);
+
+			lines[4] =
+				L"Size: " +
+				std::to_wstring(desc.Width) +
+				L"x" +
+				std::to_wstring(desc.Height) +
+				L"x" +
+				std::to_wstring(desc.Depth);
+
+			lines[5] =
+				L"Mips: " +
+				std::to_wstring(desc.MipLevels);
+
+			lines[6] =
+				L"Bind: " +
+				std::to_wstring(
+					static_cast<unsigned>(
+						resource->bind_flags
+						)
+				);
+
+			lines[7] =
+				L"Misc: " +
+				std::to_wstring(
+					static_cast<unsigned>(
+						resource->misc_flags
+						)
+				);
+
+			lines[8] =
+				L"SourceStride: " +
+				std::to_wstring(
+					resource->source_stride
+				);
+
+			break;
+		}
+
+
+		default:
+			lines[3] = L"Format: Unknown";
+			break;
+		}
+	}
+	else
+	{
+		// ====================================================================
+		// Resource hasn't been substantiated yet.
+		// Use the description known from the Resource declaration.
+		// ====================================================================
+
+		lines[2] =
+			L"Type: " +
+			CustomResourceTypeToWString(
+				resource->override_type
+			);
+
+		lines[3] =
+			L"Format: " +
+			FormatToWString(
+				resource->override_format
+			);
+
+		lines[4] =
+			L"Width: " +
+			std::to_wstring(
+				resource->override_width
+			);
+
+		lines[5] =
+			L"Height: " +
+			std::to_wstring(
+				resource->override_height
+			);
+
+		lines[6] =
+			L"Depth: " +
+			std::to_wstring(
+				resource->override_depth
+			);
+
+		lines[7] =
+			L"Mips: " +
+			std::to_wstring(
+				resource->override_mips
+			);
+
+		lines[8] =
+			L"Array: " +
+			std::to_wstring(
+				resource->override_array
+			);
+
+		lines[9] =
+			L"MSAA: " +
+			std::to_wstring(
+				resource->override_msaa
+			) +
+			L"/" +
+			std::to_wstring(
+				resource->override_msaa_quality
+			);
+
+		lines[10] =
+			L"ByteWidth: " +
+			std::to_wstring(
+				resource->override_byte_width
+			);
+
+		lines[11] =
+			L"Stride: " +
+			std::to_wstring(
+				resource->override_stride
+			);
+
+		lines[12] =
+			L"Bind: " +
+			std::to_wstring(
+				static_cast<unsigned>(
+					resource->override_bind_flags
+					)
+			);
+
+		lines[13] =
+			L"Misc: " +
+			std::to_wstring(
+				static_cast<unsigned>(
+					resource->override_misc_flags
+					)
+			);
+
+		lines[14] =
+			L"SourceStride: " +
+			std::to_wstring(
+				resource->source_stride
+			);
+	}
+
+
+	// ========================================================================
+	// Runtime state
+	// ========================================================================
+
+	lines[15] =
+		L"Substantiated: " +
+		std::wstring(
+			resource->substantiated
+			? L"true"
+			: L"false"
+		);
+}
+
+
+static void DrawResources()
+{
+	Profiling::text += L"\n\n";
+
+
+	// ========================================================================
+	// Namespace Counters
+	// ========================================================================
+
+	for (int c = 0;
+		c < (int)Profiling::custom_resource_columns.size();
+		c++)
+	{
+		std::wstring counter;
+
+		if (c ==
+			Profiling::active_custom_resource_column)
+		{
+			auto& column =
+				Profiling::custom_resource_columns[c];
+
+			if (
+				column.namespace_index >= 0 &&
+				column.namespace_index <
+				(int)custom_resource_namespace_list.size()
+				)
+			{
+				counter =
+					std::to_wstring(
+						column.namespace_index + 1
+					) +
+					L"/" +
+					std::to_wstring(
+						custom_resource_namespace_list.size()
+					);
+			}
+			else
+			{
+				counter =
+					L"0/" +
+					std::to_wstring(
+						custom_resource_namespace_list.size()
+					);
+			}
+		}
+
+		AddColumn(
+			Profiling::text,
+			counter,
+			Profiling::column_width
+		);
+	}
+
+	Profiling::text += L"\n";
+
+
+	// ========================================================================
+	// Namespace Headers
+	// ========================================================================
+
+	for (int c = 0;
+		c < (int)Profiling::custom_resource_columns.size();
+		c++)
+	{
+		AddColumn(
+			Profiling::text,
+			TrimText(
+				GetCustomResourceColumnHeader(c),
+				Profiling::column_width
+			),
+			Profiling::column_width
+		);
+	}
+
+	Profiling::text += L"\n";
+
+
+	// ========================================================================
+	// Resource List
+	// ========================================================================
+
+	for (
+		int row = 0;
+		row < Profiling::custom_resource_visible_rows;
+		row++
+		)
+	{
+		for (
+			int c = 0;
+			c < (int)Profiling::custom_resource_columns.size();
+			c++
+			)
+		{
+			auto& column =
+				Profiling::custom_resource_columns[c];
+
+			std::wstring text;
+
+			if (
+				column.namespace_index >= 0 &&
+				column.namespace_index <
+				(int)custom_resource_namespace_list.size()
+				)
+			{
+				auto& resources =
+					custom_resource_groups[
+						custom_resource_namespace_list[
+							column.namespace_index
+						]
+					];
+
+				int index =
+					row +
+					column.scroll_offset;
+
+				if (
+					index >= 0 &&
+					index < (int)resources.size()
+					)
+				{
+					CustomResourceEntry* entry =
+						resources[index];
+
+					text = GetLastPathComponent(
+						entry->name
+					);
+
+					if (index == column.resource_index)
+						text = L"> " + text;
+				}
+			}
+
+			AddColumn(
+				Profiling::text,
+				TrimText(
+					text,
+					Profiling::column_width
+				),
+				Profiling::column_width
+			);
+		}
+
+		Profiling::text += L"\n";
+	}
+
+
+	// ========================================================================
+	// Separator
+	// ========================================================================
+
+	for (int c = 0;
+		c < (int)Profiling::custom_resource_columns.size();
+		c++)
+	{
+		AddColumn(
+			Profiling::text,
+			L"----------------------------------------",
+			Profiling::column_width
+		);
+	}
+
+	Profiling::text += L"\n";
+
+
+	// ========================================================================
+	// Selected Resource Metadata
+	// ========================================================================
+
+	for (
+		int row = 0;
+		row < Profiling::custom_resource_metadata_rows;
+		row++
+		)
+	{
+		for (
+			int c = 0;
+			c < (int)Profiling::custom_resource_columns.size();
+			c++
+			)
+		{
+			auto& column =
+				Profiling::custom_resource_columns[c];
+
+			std::wstring text;
+
+			if (
+				column.namespace_index >= 0 &&
+				column.namespace_index <
+				(int)custom_resource_namespace_list.size()
+				)
+			{
+				auto& resources =
+					custom_resource_groups[
+						custom_resource_namespace_list[
+							column.namespace_index
+						]
+					];
+
+				if (
+					column.resource_index >= 0 &&
+					column.resource_index <
+					(int)resources.size()
+					)
+				{
+					CustomResource* resource =
+						resources[
+							column.resource_index
+						]->resource;
+
+					std::wstring lines[16];
+
+					GetResourceMetadata(
+						resource,
+						lines
+					);
+
+					text =
+						lines[row];
+				}
+			}
+
+			AddColumn(
+				Profiling::text,
+				TrimText(
+					text,
+					Profiling::column_width
+				),
 				Profiling::column_width
 			);
 		}
@@ -590,7 +1629,8 @@ void Profiling::update_txt()
 		return;
 
 	collection_duration.QuadPart = (end_time.QuadPart - profiling_start_time.QuadPart) * 1000000 / freq.QuadPart;
-	if (collection_duration.QuadPart < ((Profiling::mode == Profiling::Mode::COMMAND_LIST_VARIABLES) ? 0.1 : interval) && !Profiling::text.empty())
+	if (collection_duration.QuadPart < ((Profiling::mode == Profiling::Mode::COMMAND_LIST_VARIABLES || Profiling::mode == Profiling::Mode::CUSTOM_RESOURCE_POOLS) ? 0.1 : interval)
+		&& !Profiling::text.empty())
 		return;
 
 	if (frames && collection_duration.QuadPart) {
@@ -613,6 +1653,12 @@ void Profiling::update_txt()
 				break;
 			case Profiling::Mode::COMMAND_LIST_VARIABLES:
 				DrawVariables();
+				break;
+			case Profiling::Mode::CUSTOM_RESOURCES:
+				DrawResources();
+				break;
+			case Profiling::Mode::CUSTOM_RESOURCE_POOLS:
+				DrawResourcePools();
 				break;
 		}
 	}

--- a/DirectX11/profiling.h
+++ b/DirectX11/profiling.h
@@ -2,6 +2,7 @@
 
 #include <wrl.h>
 #include <string>
+#include <vector>
 
 namespace Profiling {
 	enum class Mode {
@@ -10,6 +11,7 @@ namespace Profiling {
 		TOP_COMMAND_LISTS,
 		TOP_COMMANDS,
 		CTO_WARNING,
+		COMMAND_LIST_VARIABLES,
 
 		INVALID, // Must be last
 	};
@@ -98,4 +100,15 @@ namespace Profiling {
 	extern unsigned max_executions_per_frame_exceeded;
 	extern unsigned iniparams_updates;
 
+	struct VariableColumn
+	{
+		int namespace_index = -1;
+		int scroll_offset = 0;
+	};
+
+	extern std::vector<VariableColumn> variable_columns;
+	extern int active_column;
+
+	extern const int column_width;
+	extern const int visible_rows;
 }

--- a/DirectX11/profiling.h
+++ b/DirectX11/profiling.h
@@ -12,6 +12,8 @@ namespace Profiling {
 		TOP_COMMANDS,
 		CTO_WARNING,
 		COMMAND_LIST_VARIABLES,
+		CUSTOM_RESOURCES,
+		CUSTOM_RESOURCE_POOLS,
 
 		INVALID, // Must be last
 	};
@@ -100,6 +102,10 @@ namespace Profiling {
 	extern unsigned max_executions_per_frame_exceeded;
 	extern unsigned iniparams_updates;
 
+	// Values Viewer
+
+	// Variables
+
 	struct VariableColumn
 	{
 		int namespace_index = -1;
@@ -109,6 +115,32 @@ namespace Profiling {
 	extern std::vector<VariableColumn> variable_columns;
 	extern int active_column;
 
+	// Pools
+
+	struct ResourcePoolColumn
+	{
+		int pool_index = -1;
+		int scroll_offset = 0;
+	};
+
+	extern std::vector<ResourcePoolColumn> resource_pool_columns;
+	extern int active_pool_column;
+
 	extern const int column_width;
 	extern const int visible_rows;
+
+	// Custom Resources
+
+	struct CustomResourceColumn
+	{
+		int namespace_index = -1;
+		int resource_index = 0;
+		int scroll_offset = 0;
+	};
+
+	extern std::vector<CustomResourceColumn> custom_resource_columns;
+	extern int active_custom_resource_column;
+
+	extern const int custom_resource_visible_rows;
+	extern const int custom_resource_metadata_rows;
 }


### PR DESCRIPTION
Allows to Display up to 61 Variables per Column for 6 Different NameSpaces/Files at once (on FHD Screen)

Default KeyBinds:

; Change Selected Columns
cycle_namespace_column = VK_TAB

; Next NameSpace/File for Selected Column
next_namespace = VK_RIGHT

; Previous NameSpace/File for Selected Column
previous_namespace = VK_LEFT

; Next Variable for Selected Column (in Case they don't fit on the Screen)
next_var = VK_UP

; Previous Variable for Selected Column (in Case they don't fit on the Screen)
previous_var = VK_DOWN